### PR TITLE
Fix for Tunnelblick on OS X

### DIFF
--- a/linux/cstorm_linux-dynamic_udp.ovpn
+++ b/linux/cstorm_linux-dynamic_udp.ovpn
@@ -52,7 +52,7 @@ remote linux-rome.cryptostorm.net 443 udp
 remote linux-rome.cryptostorm.nu 443 udp
 remote linux-rome.cryptostorm.org 443 udp
 remote linux-rome.cstorm.pw 443 udp
-txqueuelen 686
+#txqueuelen 686
 sndbuf size 1655368
 rcvbuf size 1655368
 explicit-exit-notify 3


### PR DESCRIPTION
commented out: txqueuelen 686 as it's not compatible with OS X/Tunnelblick 3.6.0a client
