### PR TITLE
Specify that ca is inline rather than in a separate file

### DIFF
--- a/cryptofree_android-tcp.ovpn
+++ b/cryptofree_android-tcp.ovpn
@@ -16,7 +16,7 @@ down-pre
 allow-pull-fqdn
 hand-window 37
 auth-user-pass
-ca ca.crt
+ca [inline]
 <ca>
 -----BEGIN CERTIFICATE-----
 MIIFHjCCBAagAwIBAgIJAKekpGXxXvhbMA0GCSqGSIb3DQEBCwUAMIG6MQswCQYD

--- a/cryptofree_android-udp.ovpn
+++ b/cryptofree_android-udp.ovpn
@@ -18,7 +18,7 @@ explicit-exit-notify 3
 hand-window 37
 mssfix 1400
 auth-user-pass
-ca ca.crt
+ca [inline]
 <ca>
 -----BEGIN CERTIFICATE-----
 MIIFHjCCBAagAwIBAgIJAKekpGXxXvhbMA0GCSqGSIb3DQEBCwUAMIG6MQswCQYD

--- a/cryptofree_linux-tcp.ovpn
+++ b/cryptofree_linux-tcp.ovpn
@@ -17,7 +17,7 @@ down-pre
 allow-pull-fqdn
 hand-window 37
 auth-user-pass
-ca ca.crt
+ca [inline]
 <ca>
 -----BEGIN CERTIFICATE-----
 MIIFHjCCBAagAwIBAgIJAKekpGXxXvhbMA0GCSqGSIb3DQEBCwUAMIG6MQswCQYD

--- a/cryptofree_linux-udp.ovpn
+++ b/cryptofree_linux-udp.ovpn
@@ -19,7 +19,7 @@ explicit-exit-notify 3
 hand-window 37
 mssfix 1400
 auth-user-pass
-ca ca.crt
+ca [inline]
 <ca>
 -----BEGIN CERTIFICATE-----
 MIIFHjCCBAagAwIBAgIJAKekpGXxXvhbMA0GCSqGSIb3DQEBCwUAMIG6MQswCQYD

--- a/cryptofree_windows-tcp.ovpn
+++ b/cryptofree_windows-tcp.ovpn
@@ -22,7 +22,7 @@ cipher AES-256-CBC
 tls-cipher TLS-DHE-RSA-WITH-AES-256-CBC-SHA
 tls-client
 key-method 2
-ca ca.crt
+ca [inline]
 # specification & location of server-verification PKI materials
 # for details, see http://pki.cryptostorm.org
 <ca>

--- a/cryptofree_windows-udp.ovpn
+++ b/cryptofree_windows-udp.ovpn
@@ -24,7 +24,7 @@ cipher AES-256-CBC
 tls-cipher TLS-DHE-RSA-WITH-AES-256-CBC-SHA
 tls-client
 key-method 2
-ca ca.crt
+ca [inline]
 # specification & location of server-verification PKI materials
 # for details, see http://pki.cryptostorm.org
 <ca>

--- a/linux/cstorm_linux-dynamic_tcp.ovpn
+++ b/linux/cstorm_linux-dynamic_tcp.ovpn
@@ -77,7 +77,7 @@ cipher AES-256-CBC
 tls-cipher TLS-DHE-RSA-WITH-AES-256-CBC-SHA
 tls-client
 key-method 2
-ca ca.crt
+ca [inline]
 # specification & location of server-verification PKI materials
 # for details, see http://pki.cryptostorm.org
 <ca>

--- a/linux/cstorm_linux-dynamic_udp.ovpn
+++ b/linux/cstorm_linux-dynamic_udp.ovpn
@@ -79,7 +79,7 @@ cipher AES-256-CBC
 tls-cipher TLS-DHE-RSA-WITH-AES-256-CBC-SHA
 tls-client
 key-method 2
-ca ca.crt
+ca [inline]
 # specification & location of server-verification PKI materials
 # for details, see http://pki.cryptostorm.org
 <ca>

--- a/linux/cstorm_linux-england_tcp.ovpn
+++ b/linux/cstorm_linux-england_tcp.ovpn
@@ -22,7 +22,7 @@ cipher AES-256-CBC
 tls-cipher TLS-DHE-RSA-WITH-AES-256-CBC-SHA
 tls-client
 key-method 2
-ca ca.crt
+ca [inline]
 # specification & location of server-verification PKI materials
 # for details, see http://pki.cryptostorm.org
 <ca>

--- a/linux/cstorm_linux-england_udp.ovpn
+++ b/linux/cstorm_linux-england_udp.ovpn
@@ -24,7 +24,7 @@ cipher AES-256-CBC
 tls-cipher TLS-DHE-RSA-WITH-AES-256-CBC-SHA
 tls-client
 key-method 2
-ca ca.crt
+ca [inline]
 # specification & location of server-verification PKI materials
 # for details, see http://pki.cryptostorm.org
 <ca>

--- a/linux/cstorm_linux-frankfurt_tcp.ovpn
+++ b/linux/cstorm_linux-frankfurt_tcp.ovpn
@@ -22,7 +22,7 @@ cipher AES-256-CBC
 tls-cipher TLS-DHE-RSA-WITH-AES-256-CBC-SHA
 tls-client
 key-method 2
-ca ca.crt
+ca [inline]
 # specification & location of server-verification PKI materials
 # for details, see http://pki.cryptostorm.org
 <ca>

--- a/linux/cstorm_linux-frankfurt_udp.ovpn
+++ b/linux/cstorm_linux-frankfurt_udp.ovpn
@@ -24,7 +24,7 @@ cipher AES-256-CBC
 tls-cipher TLS-DHE-RSA-WITH-AES-256-CBC-SHA
 tls-client
 key-method 2
-ca ca.crt
+ca [inline]
 # specification & location of server-verification PKI materials
 # for details, see http://pki.cryptostorm.org
 <ca>

--- a/linux/cstorm_linux-lisbon_tcp.ovpn
+++ b/linux/cstorm_linux-lisbon_tcp.ovpn
@@ -22,7 +22,7 @@ cipher AES-256-CBC
 tls-cipher TLS-DHE-RSA-WITH-AES-256-CBC-SHA
 tls-client
 key-method 2
-ca ca.crt
+ca [inline]
 # specification & location of server-verification PKI materials
 # for details, see http://pki.cryptostorm.org
 <ca>

--- a/linux/cstorm_linux-lisbon_udp.ovpn
+++ b/linux/cstorm_linux-lisbon_udp.ovpn
@@ -24,7 +24,7 @@ cipher AES-256-CBC
 tls-cipher TLS-DHE-RSA-WITH-AES-256-CBC-SHA
 tls-client
 key-method 2
-ca ca.crt
+ca [inline]
 # specification & location of server-verification PKI materials
 # for details, see http://pki.cryptostorm.org
 <ca>

--- a/linux/cstorm_linux-montreal_tcp.ovpn
+++ b/linux/cstorm_linux-montreal_tcp.ovpn
@@ -22,7 +22,7 @@ cipher AES-256-CBC
 tls-cipher TLS-DHE-RSA-WITH-AES-256-CBC-SHA
 tls-client
 key-method 2
-ca ca.crt
+ca [inline]
 # specification & location of server-verification PKI materials
 # for details, see http://pki.cryptostorm.org
 <ca>

--- a/linux/cstorm_linux-montreal_udp.ovpn
+++ b/linux/cstorm_linux-montreal_udp.ovpn
@@ -24,7 +24,7 @@ cipher AES-256-CBC
 tls-cipher TLS-DHE-RSA-WITH-AES-256-CBC-SHA
 tls-client
 key-method 2
-ca ca.crt
+ca [inline]
 # specification & location of server-verification PKI materials
 # for details, see http://pki.cryptostorm.org
 <ca>

--- a/linux/cstorm_linux-norway_tcp.ovpn
+++ b/linux/cstorm_linux-norway_tcp.ovpn
@@ -22,7 +22,7 @@ cipher AES-256-CBC
 tls-cipher TLS-DHE-RSA-WITH-AES-256-CBC-SHA
 tls-client
 key-method 2
-ca ca.crt
+ca [inline]
 # specification & location of server-verification PKI materials
 # for details, see http://pki.cryptostorm.org
 <ca>

--- a/linux/cstorm_linux-norway_udp.ovpn
+++ b/linux/cstorm_linux-norway_udp.ovpn
@@ -24,7 +24,7 @@ cipher AES-256-CBC
 tls-cipher TLS-DHE-RSA-WITH-AES-256-CBC-SHA
 tls-client
 key-method 2
-ca ca.crt
+ca [inline]
 # specification & location of server-verification PKI materials
 # for details, see http://pki.cryptostorm.org
 <ca>

--- a/linux/cstorm_linux-paris_tcp.ovpn
+++ b/linux/cstorm_linux-paris_tcp.ovpn
@@ -22,7 +22,7 @@ cipher AES-256-CBC
 tls-cipher TLS-DHE-RSA-WITH-AES-256-CBC-SHA
 tls-client
 key-method 2
-ca ca.crt
+ca [inline]
 # specification & location of server-verification PKI materials
 # for details, see http://pki.cryptostorm.org
 <ca>

--- a/linux/cstorm_linux-paris_udp.ovpn
+++ b/linux/cstorm_linux-paris_udp.ovpn
@@ -24,7 +24,7 @@ cipher AES-256-CBC
 tls-cipher TLS-DHE-RSA-WITH-AES-256-CBC-SHA
 tls-client
 key-method 2
-ca ca.crt
+ca [inline]
 # specification & location of server-verification PKI materials
 # for details, see http://pki.cryptostorm.org
 <ca>

--- a/linux/cstorm_linux-rome_tcp.ovpn
+++ b/linux/cstorm_linux-rome_tcp.ovpn
@@ -22,7 +22,7 @@ cipher AES-256-CBC
 tls-cipher TLS-DHE-RSA-WITH-AES-256-CBC-SHA
 tls-client
 key-method 2
-ca ca.crt
+ca [inline]
 # specification & location of server-verification PKI materials
 # for details, see http://pki.cryptostorm.org
 <ca>

--- a/linux/cstorm_linux-rome_udp.ovpn
+++ b/linux/cstorm_linux-rome_udp.ovpn
@@ -24,7 +24,7 @@ cipher AES-256-CBC
 tls-cipher TLS-DHE-RSA-WITH-AES-256-CBC-SHA
 tls-client
 key-method 2
-ca ca.crt
+ca [inline]
 # specification & location of server-verification PKI materials
 # for details, see http://pki.cryptostorm.org
 <ca>

--- a/linux/cstorm_linux-smoothed_tcp.ovpn
+++ b/linux/cstorm_linux-smoothed_tcp.ovpn
@@ -22,7 +22,7 @@ cipher AES-256-CBC
 tls-cipher TLS-DHE-RSA-WITH-AES-256-CBC-SHA
 tls-client
 key-method 2
-ca ca.crt
+ca [inline]
 # specification & location of server-verification PKI materials
 # for details, see http://pki.cryptostorm.org
 <ca>

--- a/linux/cstorm_linux-smoothed_udp.ovpn
+++ b/linux/cstorm_linux-smoothed_udp.ovpn
@@ -24,7 +24,7 @@ cipher AES-256-CBC
 tls-cipher TLS-DHE-RSA-WITH-AES-256-CBC-SHA
 tls-client
 key-method 2
-ca ca.crt
+ca [inline]
 # specification & location of server-verification PKI materials
 # for details, see http://pki.cryptostorm.org
 <ca>

--- a/linux/cstorm_linux-southkorea_tcp.ovpn
+++ b/linux/cstorm_linux-southkorea_tcp.ovpn
@@ -22,7 +22,7 @@ cipher AES-256-CBC
 tls-cipher TLS-DHE-RSA-WITH-AES-256-CBC-SHA
 tls-client
 key-method 2
-ca ca.crt
+ca [inline]
 # specification & location of server-verification PKI materials
 # for details, see http://pki.cryptostorm.org
 <ca>

--- a/linux/cstorm_linux-southkorea_udp.ovpn
+++ b/linux/cstorm_linux-southkorea_udp.ovpn
@@ -24,7 +24,7 @@ cipher AES-256-CBC
 tls-cipher TLS-DHE-RSA-WITH-AES-256-CBC-SHA
 tls-client
 key-method 2
-ca ca.crt
+ca [inline]
 # specification & location of server-verification PKI materials
 # for details, see http://pki.cryptostorm.org
 <ca>

--- a/linux/cstorm_linux-switzerland_tcp.ovpn
+++ b/linux/cstorm_linux-switzerland_tcp.ovpn
@@ -22,7 +22,7 @@ cipher AES-256-CBC
 tls-cipher TLS-DHE-RSA-WITH-AES-256-CBC-SHA
 tls-client
 key-method 2
-ca ca.crt
+ca [inline]
 # specification & location of server-verification PKI materials
 # for details, see http://pki.cryptostorm.org
 <ca>

--- a/linux/cstorm_linux-switzerland_udp.ovpn
+++ b/linux/cstorm_linux-switzerland_udp.ovpn
@@ -24,7 +24,7 @@ cipher AES-256-CBC
 tls-cipher TLS-DHE-RSA-WITH-AES-256-CBC-SHA
 tls-client
 key-method 2
-ca ca.crt
+ca [inline]
 # specification & location of server-verification PKI materials
 # for details, see http://pki.cryptostorm.org
 <ca>

--- a/linux/cstorm_linux-uscentral_tcp.ovpn
+++ b/linux/cstorm_linux-uscentral_tcp.ovpn
@@ -22,7 +22,7 @@ cipher AES-256-CBC
 tls-cipher TLS-DHE-RSA-WITH-AES-256-CBC-SHA
 tls-client
 key-method 2
-ca ca.crt
+ca [inline]
 # specification & location of server-verification PKI materials
 # for details, see http://pki.cryptostorm.org
 <ca>

--- a/linux/cstorm_linux-uscentral_udp.ovpn
+++ b/linux/cstorm_linux-uscentral_udp.ovpn
@@ -24,7 +24,7 @@ cipher AES-256-CBC
 tls-cipher TLS-DHE-RSA-WITH-AES-256-CBC-SHA
 tls-client
 key-method 2
-ca ca.crt
+ca [inline]
 # specification & location of server-verification PKI materials
 # for details, see http://pki.cryptostorm.org
 <ca>

--- a/linux/cstorm_linux-useast_tcp.ovpn
+++ b/linux/cstorm_linux-useast_tcp.ovpn
@@ -22,7 +22,7 @@ cipher AES-256-CBC
 tls-cipher TLS-DHE-RSA-WITH-AES-256-CBC-SHA
 tls-client
 key-method 2
-ca ca.crt
+ca [inline]
 # specification & location of server-verification PKI materials
 # for details, see http://pki.cryptostorm.org
 <ca>

--- a/linux/cstorm_linux-useast_udp.ovpn
+++ b/linux/cstorm_linux-useast_udp.ovpn
@@ -24,7 +24,7 @@ cipher AES-256-CBC
 tls-cipher TLS-DHE-RSA-WITH-AES-256-CBC-SHA
 tls-client
 key-method 2
-ca ca.crt
+ca [inline]
 # specification & location of server-verification PKI materials
 # for details, see http://pki.cryptostorm.org
 <ca>

--- a/linux/cstorm_linux-usnorth_tcp.ovpn
+++ b/linux/cstorm_linux-usnorth_tcp.ovpn
@@ -22,7 +22,7 @@ cipher AES-256-CBC
 tls-cipher TLS-DHE-RSA-WITH-AES-256-CBC-SHA
 tls-client
 key-method 2
-ca ca.crt
+ca [inline]
 # specification & location of server-verification PKI materials
 # for details, see http://pki.cryptostorm.org
 <ca>

--- a/linux/cstorm_linux-usnorth_udp.ovpn
+++ b/linux/cstorm_linux-usnorth_udp.ovpn
@@ -24,7 +24,7 @@ cipher AES-256-CBC
 tls-cipher TLS-DHE-RSA-WITH-AES-256-CBC-SHA
 tls-client
 key-method 2
-ca ca.crt
+ca [inline]
 # specification & location of server-verification PKI materials
 # for details, see http://pki.cryptostorm.org
 <ca>

--- a/linux/cstorm_linux-ussouth_tcp.ovpn
+++ b/linux/cstorm_linux-ussouth_tcp.ovpn
@@ -22,7 +22,7 @@ cipher AES-256-CBC
 tls-cipher TLS-DHE-RSA-WITH-AES-256-CBC-SHA
 tls-client
 key-method 2
-ca ca.crt
+ca [inline]
 # specification & location of server-verification PKI materials
 # for details, see http://pki.cryptostorm.org
 <ca>

--- a/linux/cstorm_linux-ussouth_udp.ovpn
+++ b/linux/cstorm_linux-ussouth_udp.ovpn
@@ -24,7 +24,7 @@ cipher AES-256-CBC
 tls-cipher TLS-DHE-RSA-WITH-AES-256-CBC-SHA
 tls-client
 key-method 2
-ca ca.crt
+ca [inline]
 # specification & location of server-verification PKI materials
 # for details, see http://pki.cryptostorm.org
 <ca>

--- a/linux/cstorm_linux-uswest_tcp.ovpn
+++ b/linux/cstorm_linux-uswest_tcp.ovpn
@@ -22,7 +22,7 @@ cipher AES-256-CBC
 tls-cipher TLS-DHE-RSA-WITH-AES-256-CBC-SHA
 tls-client
 key-method 2
-ca ca.crt
+ca [inline]
 # specification & location of server-verification PKI materials
 # for details, see http://pki.cryptostorm.org
 <ca>

--- a/linux/cstorm_linux-uswest_udp.ovpn
+++ b/linux/cstorm_linux-uswest_udp.ovpn
@@ -24,7 +24,7 @@ cipher AES-256-CBC
 tls-cipher TLS-DHE-RSA-WITH-AES-256-CBC-SHA
 tls-client
 key-method 2
-ca ca.crt
+ca [inline]
 # specification & location of server-verification PKI materials
 # for details, see http://pki.cryptostorm.org
 <ca>

--- a/voodoo/cstorm-voodoo_linux-romania_to_russia.ovpn
+++ b/voodoo/cstorm-voodoo_linux-romania_to_russia.ovpn
@@ -24,7 +24,7 @@ cipher AES-256-CBC
 tls-cipher TLS-DHE-RSA-WITH-AES-256-CBC-SHA
 tls-client
 key-method 2
-ca ca.crt
+ca [inline]
 # specification & location of server-verification PKI materials
 # for details, see http://pki.cryptostorm.org
 <ca>

--- a/voodoo/cstorm-voodoo_linux-ussouth_to_isleofman.ovpn
+++ b/voodoo/cstorm-voodoo_linux-ussouth_to_isleofman.ovpn
@@ -24,7 +24,7 @@ cipher AES-256-CBC
 tls-cipher TLS-DHE-RSA-WITH-AES-256-CBC-SHA
 tls-client
 key-method 2
-ca ca.crt
+ca [inline]
 # specification & location of server-verification PKI materials
 # for details, see http://pki.cryptostorm.org
 <ca>

--- a/voodoo/cstorm-voodoo_linux-uswest_to_iceland.ovpn
+++ b/voodoo/cstorm-voodoo_linux-uswest_to_iceland.ovpn
@@ -24,7 +24,7 @@ cipher AES-256-CBC
 tls-cipher TLS-DHE-RSA-WITH-AES-256-CBC-SHA
 tls-client
 key-method 2
-ca ca.crt
+ca [inline]
 # specification & location of server-verification PKI materials
 # for details, see http://pki.cryptostorm.org
 <ca>

--- a/voodoo/cstorm-voodoo_windows-italy_to_romania.ovpn
+++ b/voodoo/cstorm-voodoo_windows-italy_to_romania.ovpn
@@ -24,7 +24,7 @@ cipher AES-256-CBC
 tls-cipher TLS-DHE-RSA-WITH-AES-256-CBC-SHA
 tls-client
 key-method 2
-ca ca.crt
+ca [inline]
 # specification & location of server-verification PKI materials
 # for details, see http://pki.cryptostorm.org
 <ca>

--- a/voodoo/cstorm-voodoo_windows-romania_to_russia.ovpn
+++ b/voodoo/cstorm-voodoo_windows-romania_to_russia.ovpn
@@ -24,7 +24,7 @@ cipher AES-256-CBC
 tls-cipher TLS-DHE-RSA-WITH-AES-256-CBC-SHA
 tls-client
 key-method 2
-ca ca.crt
+ca [inline]
 # specification & location of server-verification PKI materials
 # for details, see http://pki.cryptostorm.org
 <ca>

--- a/voodoo/cstorm-voodoo_windows-uswest_to_iceland.ovpn
+++ b/voodoo/cstorm-voodoo_windows-uswest_to_iceland.ovpn
@@ -24,7 +24,7 @@ cipher AES-256-CBC
 tls-cipher TLS-DHE-RSA-WITH-AES-256-CBC-SHA
 tls-client
 key-method 2
-ca ca.crt
+ca [inline]
 # specification & location of server-verification PKI materials
 # for details, see http://pki.cryptostorm.org
 <ca>

--- a/voodoo/cstorm-voodoo_windows-uswest_to_isleofman.ovpn
+++ b/voodoo/cstorm-voodoo_windows-uswest_to_isleofman.ovpn
@@ -24,7 +24,7 @@ cipher AES-256-CBC
 tls-cipher TLS-DHE-RSA-WITH-AES-256-CBC-SHA
 tls-client
 key-method 2
-ca ca.crt
+ca [inline]
 # specification & location of server-verification PKI materials
 # for details, see http://pki.cryptostorm.org
 <ca>

--- a/windows/cstorm_windows-dynamic_tcp.ovpn
+++ b/windows/cstorm_windows-dynamic_tcp.ovpn
@@ -74,7 +74,7 @@ cipher AES-256-CBC
 tls-cipher TLS-DHE-RSA-WITH-AES-256-CBC-SHA
 tls-client
 key-method 2
-ca ca.crt
+ca [inline]
 # specification & location of server-verification PKI materials
 # for details, see http://pki.cryptostorm.org
 <ca>

--- a/windows/cstorm_windows-dynamic_udp.ovpn
+++ b/windows/cstorm_windows-dynamic_udp.ovpn
@@ -76,7 +76,7 @@ cipher AES-256-CBC
 tls-cipher TLS-DHE-RSA-WITH-AES-256-CBC-SHA
 tls-client
 key-method 2
-ca ca.crt
+ca [inline]
 # specification & location of server-verification PKI materials
 # for details, see http://pki.cryptostorm.org
 <ca>

--- a/windows/cstorm_windows-england_tcp.ovpn
+++ b/windows/cstorm_windows-england_tcp.ovpn
@@ -22,7 +22,7 @@ cipher AES-256-CBC
 tls-cipher TLS-DHE-RSA-WITH-AES-256-CBC-SHA
 tls-client
 key-method 2
-ca ca.crt
+ca [inline]
 # specification & location of server-verification PKI materials
 # for details, see http://pki.cryptostorm.org
 <ca>

--- a/windows/cstorm_windows-england_udp.ovpn
+++ b/windows/cstorm_windows-england_udp.ovpn
@@ -24,7 +24,7 @@ cipher AES-256-CBC
 tls-cipher TLS-DHE-RSA-WITH-AES-256-CBC-SHA
 tls-client
 key-method 2
-ca ca.crt
+ca [inline]
 # specification & location of server-verification PKI materials
 # for details, see http://pki.cryptostorm.org
 <ca>

--- a/windows/cstorm_windows-frankfurt_tcp.ovpn
+++ b/windows/cstorm_windows-frankfurt_tcp.ovpn
@@ -22,7 +22,7 @@ cipher AES-256-CBC
 tls-cipher TLS-DHE-RSA-WITH-AES-256-CBC-SHA
 tls-client
 key-method 2
-ca ca.crt
+ca [inline]
 # specification & location of server-verification PKI materials
 # for details, see http://pki.cryptostorm.org
 <ca>

--- a/windows/cstorm_windows-frankfurt_udp.ovpn
+++ b/windows/cstorm_windows-frankfurt_udp.ovpn
@@ -24,7 +24,7 @@ cipher AES-256-CBC
 tls-cipher TLS-DHE-RSA-WITH-AES-256-CBC-SHA
 tls-client
 key-method 2
-ca ca.crt
+ca [inline]
 # specification & location of server-verification PKI materials
 # for details, see http://pki.cryptostorm.org
 <ca>

--- a/windows/cstorm_windows-lisbon_tcp.ovpn
+++ b/windows/cstorm_windows-lisbon_tcp.ovpn
@@ -22,7 +22,7 @@ cipher AES-256-CBC
 tls-cipher TLS-DHE-RSA-WITH-AES-256-CBC-SHA
 tls-client
 key-method 2
-ca ca.crt
+ca [inline]
 # specification & location of server-verification PKI materials
 # for details, see http://pki.cryptostorm.org
 <ca>

--- a/windows/cstorm_windows-lisbon_udp.ovpn
+++ b/windows/cstorm_windows-lisbon_udp.ovpn
@@ -24,7 +24,7 @@ cipher AES-256-CBC
 tls-cipher TLS-DHE-RSA-WITH-AES-256-CBC-SHA
 tls-client
 key-method 2
-ca ca.crt
+ca [inline]
 # specification & location of server-verification PKI materials
 # for details, see http://pki.cryptostorm.org
 <ca>

--- a/windows/cstorm_windows-montreal_tcp.ovpn
+++ b/windows/cstorm_windows-montreal_tcp.ovpn
@@ -22,7 +22,7 @@ cipher AES-256-CBC
 tls-cipher TLS-DHE-RSA-WITH-AES-256-CBC-SHA
 tls-client
 key-method 2
-ca ca.crt
+ca [inline]
 # specification & location of server-verification PKI materials
 # for details, see http://pki.cryptostorm.org
 <ca>

--- a/windows/cstorm_windows-montreal_udp.ovpn
+++ b/windows/cstorm_windows-montreal_udp.ovpn
@@ -24,7 +24,7 @@ cipher AES-256-CBC
 tls-cipher TLS-DHE-RSA-WITH-AES-256-CBC-SHA
 tls-client
 key-method 2
-ca ca.crt
+ca [inline]
 # specification & location of server-verification PKI materials
 # for details, see http://pki.cryptostorm.org
 <ca>

--- a/windows/cstorm_windows-norway_tcp.ovpn
+++ b/windows/cstorm_windows-norway_tcp.ovpn
@@ -22,7 +22,7 @@ cipher AES-256-CBC
 tls-cipher TLS-DHE-RSA-WITH-AES-256-CBC-SHA
 tls-client
 key-method 2
-ca ca.crt
+ca [inline]
 # specification & location of server-verification PKI materials
 # for details, see http://pki.cryptostorm.org
 <ca>

--- a/windows/cstorm_windows-norway_udp.ovpn
+++ b/windows/cstorm_windows-norway_udp.ovpn
@@ -24,7 +24,7 @@ cipher AES-256-CBC
 tls-cipher TLS-DHE-RSA-WITH-AES-256-CBC-SHA
 tls-client
 key-method 2
-ca ca.crt
+ca [inline]
 # specification & location of server-verification PKI materials
 # for details, see http://pki.cryptostorm.org
 <ca>

--- a/windows/cstorm_windows-paris_tcp.ovpn
+++ b/windows/cstorm_windows-paris_tcp.ovpn
@@ -22,7 +22,7 @@ cipher AES-256-CBC
 tls-cipher TLS-DHE-RSA-WITH-AES-256-CBC-SHA
 tls-client
 key-method 2
-ca ca.crt
+ca [inline]
 # specification & location of server-verification PKI materials
 # for details, see http://pki.cryptostorm.org
 <ca>

--- a/windows/cstorm_windows-paris_udp.ovpn
+++ b/windows/cstorm_windows-paris_udp.ovpn
@@ -24,7 +24,7 @@ cipher AES-256-CBC
 tls-cipher TLS-DHE-RSA-WITH-AES-256-CBC-SHA
 tls-client
 key-method 2
-ca ca.crt
+ca [inline]
 # specification & location of server-verification PKI materials
 # for details, see http://pki.cryptostorm.org
 <ca>

--- a/windows/cstorm_windows-rome_tcp.ovpn
+++ b/windows/cstorm_windows-rome_tcp.ovpn
@@ -22,7 +22,7 @@ cipher AES-256-CBC
 tls-cipher TLS-DHE-RSA-WITH-AES-256-CBC-SHA
 tls-client
 key-method 2
-ca ca.crt
+ca [inline]
 # specification & location of server-verification PKI materials
 # for details, see http://pki.cryptostorm.org
 <ca>

--- a/windows/cstorm_windows-rome_udp.ovpn
+++ b/windows/cstorm_windows-rome_udp.ovpn
@@ -24,7 +24,7 @@ cipher AES-256-CBC
 tls-cipher TLS-DHE-RSA-WITH-AES-256-CBC-SHA
 tls-client
 key-method 2
-ca ca.crt
+ca [inline]
 # specification & location of server-verification PKI materials
 # for details, see http://pki.cryptostorm.org
 <ca>

--- a/windows/cstorm_windows-smoothed_tcp.ovpn
+++ b/windows/cstorm_windows-smoothed_tcp.ovpn
@@ -22,7 +22,7 @@ cipher AES-256-CBC
 tls-cipher TLS-DHE-RSA-WITH-AES-256-CBC-SHA
 tls-client
 key-method 2
-ca ca.crt
+ca [inline]
 # specification & location of server-verification PKI materials
 # for details, see http://pki.cryptostorm.org
 <ca>

--- a/windows/cstorm_windows-smoothed_udp.ovpn
+++ b/windows/cstorm_windows-smoothed_udp.ovpn
@@ -24,7 +24,7 @@ cipher AES-256-CBC
 tls-cipher TLS-DHE-RSA-WITH-AES-256-CBC-SHA
 tls-client
 key-method 2
-ca ca.crt
+ca [inline]
 # specification & location of server-verification PKI materials
 # for details, see http://pki.cryptostorm.org
 <ca>

--- a/windows/cstorm_windows-southkorea_tcp.ovpn
+++ b/windows/cstorm_windows-southkorea_tcp.ovpn
@@ -22,7 +22,7 @@ cipher AES-256-CBC
 tls-cipher TLS-DHE-RSA-WITH-AES-256-CBC-SHA
 tls-client
 key-method 2
-ca ca.crt
+ca [inline]
 # specification & location of server-verification PKI materials
 # for details, see http://pki.cryptostorm.org
 <ca>

--- a/windows/cstorm_windows-southkorea_udp.ovpn
+++ b/windows/cstorm_windows-southkorea_udp.ovpn
@@ -24,7 +24,7 @@ cipher AES-256-CBC
 tls-cipher TLS-DHE-RSA-WITH-AES-256-CBC-SHA
 tls-client
 key-method 2
-ca ca.crt
+ca [inline]
 # specification & location of server-verification PKI materials
 # for details, see http://pki.cryptostorm.org
 <ca>

--- a/windows/cstorm_windows-switzerland_tcp.ovpn
+++ b/windows/cstorm_windows-switzerland_tcp.ovpn
@@ -22,7 +22,7 @@ cipher AES-256-CBC
 tls-cipher TLS-DHE-RSA-WITH-AES-256-CBC-SHA
 tls-client
 key-method 2
-ca ca.crt
+ca [inline]
 # specification & location of server-verification PKI materials
 # for details, see http://pki.cryptostorm.org
 <ca>

--- a/windows/cstorm_windows-switzerland_udp.ovpn
+++ b/windows/cstorm_windows-switzerland_udp.ovpn
@@ -24,7 +24,7 @@ cipher AES-256-CBC
 tls-cipher TLS-DHE-RSA-WITH-AES-256-CBC-SHA
 tls-client
 key-method 2
-ca ca.crt
+ca [inline]
 # specification & location of server-verification PKI materials
 # for details, see http://pki.cryptostorm.org
 <ca>

--- a/windows/cstorm_windows-uscentral_tcp.ovpn
+++ b/windows/cstorm_windows-uscentral_tcp.ovpn
@@ -22,7 +22,7 @@ cipher AES-256-CBC
 tls-cipher TLS-DHE-RSA-WITH-AES-256-CBC-SHA
 tls-client
 key-method 2
-ca ca.crt
+ca [inline]
 # specification & location of server-verification PKI materials
 # for details, see http://pki.cryptostorm.org
 <ca>

--- a/windows/cstorm_windows-uscentral_udp.ovpn
+++ b/windows/cstorm_windows-uscentral_udp.ovpn
@@ -24,7 +24,7 @@ cipher AES-256-CBC
 tls-cipher TLS-DHE-RSA-WITH-AES-256-CBC-SHA
 tls-client
 key-method 2
-ca ca.crt
+ca [inline]
 # specification & location of server-verification PKI materials
 # for details, see http://pki.cryptostorm.org
 <ca>

--- a/windows/cstorm_windows-useast_tcp.ovpn
+++ b/windows/cstorm_windows-useast_tcp.ovpn
@@ -22,7 +22,7 @@ cipher AES-256-CBC
 tls-cipher TLS-DHE-RSA-WITH-AES-256-CBC-SHA
 tls-client
 key-method 2
-ca ca.crt
+ca [inline]
 # specification & location of server-verification PKI materials
 # for details, see http://pki.cryptostorm.org
 <ca>

--- a/windows/cstorm_windows-useast_udp.ovpn
+++ b/windows/cstorm_windows-useast_udp.ovpn
@@ -24,7 +24,7 @@ cipher AES-256-CBC
 tls-cipher TLS-DHE-RSA-WITH-AES-256-CBC-SHA
 tls-client
 key-method 2
-ca ca.crt
+ca [inline]
 # specification & location of server-verification PKI materials
 # for details, see http://pki.cryptostorm.org
 <ca>

--- a/windows/cstorm_windows-usnorth_tcp.ovpn
+++ b/windows/cstorm_windows-usnorth_tcp.ovpn
@@ -22,7 +22,7 @@ cipher AES-256-CBC
 tls-cipher TLS-DHE-RSA-WITH-AES-256-CBC-SHA
 tls-client
 key-method 2
-ca ca.crt
+ca [inline]
 # specification & location of server-verification PKI materials
 # for details, see http://pki.cryptostorm.org
 <ca>

--- a/windows/cstorm_windows-usnorth_udp.ovpn
+++ b/windows/cstorm_windows-usnorth_udp.ovpn
@@ -24,7 +24,7 @@ cipher AES-256-CBC
 tls-cipher TLS-DHE-RSA-WITH-AES-256-CBC-SHA
 tls-client
 key-method 2
-ca ca.crt
+ca [inline]
 # specification & location of server-verification PKI materials
 # for details, see http://pki.cryptostorm.org
 <ca>

--- a/windows/cstorm_windows-ussouth_tcp.ovpn
+++ b/windows/cstorm_windows-ussouth_tcp.ovpn
@@ -22,7 +22,7 @@ cipher AES-256-CBC
 tls-cipher TLS-DHE-RSA-WITH-AES-256-CBC-SHA
 tls-client
 key-method 2
-ca ca.crt
+ca [inline]
 # specification & location of server-verification PKI materials
 # for details, see http://pki.cryptostorm.org
 <ca>

--- a/windows/cstorm_windows-ussouth_udp.ovpn
+++ b/windows/cstorm_windows-ussouth_udp.ovpn
@@ -24,7 +24,7 @@ cipher AES-256-CBC
 tls-cipher TLS-DHE-RSA-WITH-AES-256-CBC-SHA
 tls-client
 key-method 2
-ca ca.crt
+ca [inline]
 # specification & location of server-verification PKI materials
 # for details, see http://pki.cryptostorm.org
 <ca>

--- a/windows/cstorm_windows-uswest_tcp.ovpn
+++ b/windows/cstorm_windows-uswest_tcp.ovpn
@@ -22,7 +22,7 @@ cipher AES-256-CBC
 tls-cipher TLS-DHE-RSA-WITH-AES-256-CBC-SHA
 tls-client
 key-method 2
-ca ca.crt
+ca [inline]
 # specification & location of server-verification PKI materials
 # for details, see http://pki.cryptostorm.org
 <ca>

--- a/windows/cstorm_windows-uswest_udp.ovpn
+++ b/windows/cstorm_windows-uswest_udp.ovpn
@@ -24,7 +24,7 @@ cipher AES-256-CBC
 tls-cipher TLS-DHE-RSA-WITH-AES-256-CBC-SHA
 tls-client
 key-method 2
-ca ca.crt
+ca [inline]
 # specification & location of server-verification PKI materials
 # for details, see http://pki.cryptostorm.org
 <ca>


### PR DESCRIPTION
Some clients (including NetworkManager on Ubuntu), upon importing the cert, will ignore the "<ca>" bit and interpret only the "ca ca.crt" line, thereby expecting a cert at ./ca.crt instead of the inline file. This change fixes that by explicitly specifying that the cert is inline.

This branch has not been tested except on Ubuntu. More testing is obviously needed.
