### PR TITLE
Add cryptostorm linux connect script with kill switch

### DIFF
--- a/linux/.gitignore
+++ b/linux/.gitignore
@@ -1,0 +1,1 @@
+auth.conf

--- a/linux/README.md
+++ b/linux/README.md
@@ -18,3 +18,28 @@ script-security 2
 up /etc/openvpn/update-resolv-conf
 down /etc/openvpn/update-resolv-conf
 ```
+
+A rough script is included that will allow you to connect to connect to a server without having to include any vpn commands.
+To use the script just run it
+```
+sudo cryptostorm.py
+```
+
+the script includes a killswitch this will block all connections by default other than from the tun0 interface.
+```
+sudo cryptostorm.py --killswitch
+```
+
+If the script exits incorrectly then the killswitch will need to be disabled
+```
+sudo cryptostorm.py --disable_killswitch
+```
+
+The script also allows for an auth file to be used instead of providing username and password manually. All you have to do is create in this directory a file called auth.conf and in the first line add your token and in the second line add any password.
+
+See auth.conf.example.
+
+If you need to pass any extra parameters to openvpn just use
+```
+sudo cryptostorm.py --extraparams "--script-security 2 --anotheropenvpnparam"
+```

--- a/linux/auth.conf.example
+++ b/linux/auth.conf.example
@@ -1,0 +1,2 @@
+tokensha512
+anypassword

--- a/linux/cryptostorm.py
+++ b/linux/cryptostorm.py
@@ -1,0 +1,124 @@
+#!/usr/bin/python
+
+import subprocess
+from os import listdir
+from os.path import isfile, join
+import re
+import os
+import sys
+import time
+
+import argparse
+
+parser = argparse.ArgumentParser(description='Process some integers.')
+parser.add_argument('--extraparams', metavar='N', type=str, nargs='+',
+                            help='any params to be passed to openvpn')
+parser.add_argument('--killswitch', action="store_true", default=False)
+parser.add_argument('--disable_killswitch', action="store_true", default=False)
+
+args = parser.parse_args()
+
+print args
+
+dir_path = os.path.dirname(os.path.realpath(__file__))
+print dir_path
+
+if os.geteuid() != 0:
+        exit("You need to have root privileges to run this script.\nPlease try again, this time using 'sudo'. Exiting.")
+
+## disable kill switch
+if args.disable_killswitch:
+    subprocess.check_call(dir_path + "/kill_switch.sh", shell=True)
+    sys.exit(0)
+
+p = re.compile('(cstorm_linux-|\.ovpn)') 
+
+def extract(f):
+    return p.sub('', f)
+
+configs = [f for f in listdir(dir_path) if (isfile(join(dir_path, f)) and ".ovpn" in f)]
+configs.sort()
+
+maxIndex = 0
+for f in configs:
+    print maxIndex, extract(f)
+    maxIndex += 1
+
+user_selection = 0
+user_input = ""
+while user_input == "":
+    print "Connect to [0]:",
+    user_input = raw_input()
+    try:
+        conv = int(user_input)
+        if conv >= 0 and conv < maxIndex:
+            user_selection = conv
+            break
+    except ValueError:
+        pass
+    user_input = ""
+
+cstorm_config = configs[user_selection]
+print "user chose", extract(cstorm_config)
+
+auth_file = dir_path + "/" + "auth.conf"
+
+cmd = "openvpn --config " + dir_path + "/" + cstorm_config
+
+if isfile(auth_file):
+    cmd += " --auth-user-pass " + auth_file
+
+if args.extraparams is not None:
+    for p in args.extraparams:
+        cmd += " " + p
+
+print "starting openvpn with", cmd
+openvpn = subprocess.Popen(cmd, shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+
+print "connecting"
+
+time.sleep(5)
+
+## now that we're connected enable kill switch
+if args.killswitch:
+    subprocess.check_call(dir_path + "/kill_switch.sh ENABLE", shell=True)
+
+print "connected"
+print "press any key to terminate",
+raw_input()
+print "terminating"
+
+openvpn.terminate()
+
+def get_openvpn_procs():
+    try:
+        procs = subprocess.check_output("ps aux | grep '.*openvpn.*" + cstorm_config + ".*' | grep -v grep", shell=True)
+        return procs
+    except subprocess.CalledProcessError:
+        return ""
+
+def terminate_all_openvpn():
+    procs = get_openvpn_procs()
+    if procs == "":
+        return
+    sleep_count = 0
+    while procs != "":
+        procs_split = procs.split("\n")
+        #print procs_split
+        for p in procs_split:
+            stuff = p.split()
+            if not stuff:
+                continue
+            #print stuff[1]
+            kill = "kill "
+            if sleep_count == 6:
+                kill = "kill -9 "
+            subprocess.call(kill + stuff[1], shell=True)
+        
+        time.sleep(5)
+        sleep_count += 1
+        procs = get_openvpn_procs()
+
+terminate_all_openvpn()
+print "terminated"
+subprocess.check_call(dir_path + "/kill_switch.sh", shell=True)

--- a/linux/kill_switch.sh
+++ b/linux/kill_switch.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+if [ "x$1" == "xENABLE" ]; then
+    
+    ufw default deny outgoing
+    ufw default deny incoming
+    ufw allow out on tun0 from any to any
+
+    ufw --force enable
+
+    echo "Kill switch enabled."
+else
+    ufw --force reset
+    ufw --force disable
+    echo "Kill switch disabled."
+fi
+


### PR DESCRIPTION
This adds a rough python script that allows you to connect to any server
provided by cryptostorm as long as the configs are available in the same
directory and under the same name structure: cstorm_linux-*-.ovpn
A killswitch is also provided which will block all connections except
from tun0 after tun0 has been created.

This is very rough but works for me, coded this in a day and as such opening this pull request in case you guys feel it would benefit the wider community.