### PR TITLE
Replace or remove deprecated and/or removed OpenVPN options

### DIFF
--- a/cryptofree/cryptofree_android-tcp.ovpn
+++ b/cryptofree/cryptofree_android-tcp.ovpn
@@ -8,7 +8,7 @@ remote linux-cryptofree.cryptostorm.net 443 tcp
 remote linux-cryptofree.cryptostorm.org 443 tcp
 remote linux-cryptofree.cstorm.pw 443 tcp
 remote linux-cryptofree.cryptostorm.nu 443 tcp
-comp-lzo
+compress
 down-pre
 allow-pull-fqdn
 hand-window 37
@@ -46,13 +46,12 @@ U33KzBqGs8r3UEIMWXuIGc6eXOm2Br08iFgOsUPGqp1ulvD52pFH1o1vT21v3aXl
 D9Ier/83JLMnBGctT1Kzs9OP/U0=
 -----END CERTIFICATE-----
 </ca>
-ns-cert-type server
+remote-cert-tls server
 auth SHA512
 cipher AES-256-CBC
 replay-window 128 30
 tls-cipher TLS-DHE-RSA-WITH-AES-256-CBC-SHA
 tls-client
-key-method 2
 log devnull.txt
 verb 0
 mute 1

--- a/cryptofree/cryptofree_android-tcp.ovpn
+++ b/cryptofree/cryptofree_android-tcp.ovpn
@@ -8,7 +8,7 @@ remote linux-cryptofree.cryptostorm.net 443 tcp
 remote linux-cryptofree.cryptostorm.org 443 tcp
 remote linux-cryptofree.cstorm.pw 443 tcp
 remote linux-cryptofree.cryptostorm.nu 443 tcp
-compress
+compress lzo
 down-pre
 allow-pull-fqdn
 hand-window 37

--- a/cryptofree/cryptofree_android-udp.ovpn
+++ b/cryptofree/cryptofree_android-udp.ovpn
@@ -8,7 +8,7 @@ remote linux-cryptofree.cryptostorm.net 443 udp
 remote linux-cryptofree.cryptostorm.org 443 udp
 remote linux-cryptofree.cstorm.pw 443 udp
 remote linux-cryptofree.cryptostorm.nu 443 udp
-comp-lzo
+compress
 down-pre
 allow-pull-fqdn
 explicit-exit-notify 3
@@ -48,13 +48,12 @@ U33KzBqGs8r3UEIMWXuIGc6eXOm2Br08iFgOsUPGqp1ulvD52pFH1o1vT21v3aXl
 D9Ier/83JLMnBGctT1Kzs9OP/U0=
 -----END CERTIFICATE-----
 </ca>
-ns-cert-type server
+remote-cert-tls server
 auth SHA512
 cipher AES-256-CBC
 replay-window 128 30
 tls-cipher TLS-DHE-RSA-WITH-AES-256-CBC-SHA
 tls-client
-key-method 2
 log devnull.txt
 verb 0
 mute 1

--- a/cryptofree/cryptofree_android-udp.ovpn
+++ b/cryptofree/cryptofree_android-udp.ovpn
@@ -8,7 +8,7 @@ remote linux-cryptofree.cryptostorm.net 443 udp
 remote linux-cryptofree.cryptostorm.org 443 udp
 remote linux-cryptofree.cstorm.pw 443 udp
 remote linux-cryptofree.cryptostorm.nu 443 udp
-compress
+compress lzo
 down-pre
 allow-pull-fqdn
 explicit-exit-notify 3

--- a/cryptofree/cryptofree_linux-tcp.ovpn
+++ b/cryptofree/cryptofree_linux-tcp.ovpn
@@ -9,7 +9,7 @@ remote linux-cryptofree.cryptostorm.net 443 tcp
 remote linux-cryptofree.cryptostorm.org 443 tcp
 remote linux-cryptofree.cstorm.pw 443 tcp
 remote linux-cryptofree.cryptostorm.nu 443 tcp
-comp-lzo
+compress
 down-pre
 allow-pull-fqdn
 hand-window 37
@@ -47,12 +47,11 @@ U33KzBqGs8r3UEIMWXuIGc6eXOm2Br08iFgOsUPGqp1ulvD52pFH1o1vT21v3aXl
 D9Ier/83JLMnBGctT1Kzs9OP/U0=
 -----END CERTIFICATE-----
 </ca>
-ns-cert-type server
+remote-cert-tls server
 auth SHA512
 cipher AES-256-CBC
 tls-cipher TLS-DHE-RSA-WITH-AES-256-CBC-SHA
 tls-client
-key-method 2
 log devnull.txt
 verb 0
 mute 1

--- a/cryptofree/cryptofree_linux-tcp.ovpn
+++ b/cryptofree/cryptofree_linux-tcp.ovpn
@@ -9,7 +9,7 @@ remote linux-cryptofree.cryptostorm.net 443 tcp
 remote linux-cryptofree.cryptostorm.org 443 tcp
 remote linux-cryptofree.cstorm.pw 443 tcp
 remote linux-cryptofree.cryptostorm.nu 443 tcp
-compress
+compress lzo
 down-pre
 allow-pull-fqdn
 hand-window 37

--- a/cryptofree/cryptofree_linux-udp.ovpn
+++ b/cryptofree/cryptofree_linux-udp.ovpn
@@ -9,7 +9,7 @@ remote linux-cryptofree.cryptostorm.net 443 udp
 remote linux-cryptofree.cryptostorm.org 443 udp
 remote linux-cryptofree.cstorm.pw 443 udp
 remote linux-cryptofree.cryptostorm.nu 443 udp
-compress
+compress lzo
 down-pre
 allow-pull-fqdn
 explicit-exit-notify 3

--- a/cryptofree/cryptofree_linux-udp.ovpn
+++ b/cryptofree/cryptofree_linux-udp.ovpn
@@ -9,7 +9,7 @@ remote linux-cryptofree.cryptostorm.net 443 udp
 remote linux-cryptofree.cryptostorm.org 443 udp
 remote linux-cryptofree.cstorm.pw 443 udp
 remote linux-cryptofree.cryptostorm.nu 443 udp
-comp-lzo
+compress
 down-pre
 allow-pull-fqdn
 explicit-exit-notify 3
@@ -49,13 +49,12 @@ U33KzBqGs8r3UEIMWXuIGc6eXOm2Br08iFgOsUPGqp1ulvD52pFH1o1vT21v3aXl
 D9Ier/83JLMnBGctT1Kzs9OP/U0=
 -----END CERTIFICATE-----
 </ca>
-ns-cert-type server
+remote-cert-tls server
 auth SHA512
 cipher AES-256-CBC
 replay-window 128 30
 tls-cipher TLS-DHE-RSA-WITH-AES-256-CBC-SHA
 tls-client
-key-method 2
 log devnull.txt
 verb 0
 mute 1

--- a/cryptofree/cryptofree_windows-tcp.ovpn
+++ b/cryptofree/cryptofree_windows-tcp.ovpn
@@ -9,7 +9,7 @@ remote windows-cryptofree.cryptostorm.nu 443 tcp
 remote windows-cryptofree.cryptostorm.org 443 tcp
 remote windows-cryptofree.cstorm.pw 443 tcp
 nobind
-compress
+compress lzo
 down-pre
 reneg-sec 0
 hand-window 17

--- a/cryptofree/cryptofree_windows-tcp.ovpn
+++ b/cryptofree/cryptofree_windows-tcp.ovpn
@@ -9,19 +9,18 @@ remote windows-cryptofree.cryptostorm.nu 443 tcp
 remote windows-cryptofree.cryptostorm.org 443 tcp
 remote windows-cryptofree.cstorm.pw 443 tcp
 nobind
-comp-lzo
+compress
 down-pre
 reneg-sec 0
 hand-window 17
 verb 4
 mute 3
 auth-user-pass
-ns-cert-type server
+remote-cert-tls server
 auth SHA512
 cipher AES-256-CBC
 tls-cipher TLS-DHE-RSA-WITH-AES-256-CBC-SHA
 tls-client
-key-method 2
 ca ca.crt
 # specification & location of server-verification PKI materials
 # for details, see https://cryptostorm.org/pki

--- a/cryptofree/cryptofree_windows-udp.ovpn
+++ b/cryptofree/cryptofree_windows-udp.ovpn
@@ -11,19 +11,18 @@ remote windows-cryptofree.cstorm.pw 443 udp
 explicit-exit-notify 3
 fragment 1400
 nobind
-comp-lzo
+compress
 down-pre
 reneg-sec 0
 hand-window 17
 verb 4
 mute 3
 auth-user-pass
-ns-cert-type server
+remote-cert-tls server
 auth SHA512
 cipher AES-256-CBC
 tls-cipher TLS-DHE-RSA-WITH-AES-256-CBC-SHA
 tls-client
-key-method 2
 ca ca.crt
 # specification & location of server-verification PKI materials
 # for details, see https://cryptostorm.org/pki

--- a/cryptofree/cryptofree_windows-udp.ovpn
+++ b/cryptofree/cryptofree_windows-udp.ovpn
@@ -11,7 +11,7 @@ remote windows-cryptofree.cstorm.pw 443 udp
 explicit-exit-notify 3
 fragment 1400
 nobind
-compress
+compress lzo
 down-pre
 reneg-sec 0
 hand-window 17

--- a/linux/cstorm_linux-balancer_tcp.ovpn
+++ b/linux/cstorm_linux-balancer_tcp.ovpn
@@ -9,19 +9,18 @@ remote linux-balancer.cryptostorm.nu 443 tcp
 remote linux-balancer.cryptostorm.org 443 tcp
 remote linux-balancer.cstorm.pw 443 tcp
 nobind
-comp-lzo
+compress
 down-pre
 reneg-sec 0
 hand-window 17
 verb 4
 mute 3
 auth-user-pass
-ns-cert-type server
+remote-cert-tls server
 auth SHA512
 cipher AES-256-CBC
 tls-cipher TLS-DHE-RSA-WITH-AES-256-CBC-SHA
 tls-client
-key-method 2
 ca ca.crt
 # specification & location of server-verification PKI materials
 # for details, see https://cryptostorm.org/pki

--- a/linux/cstorm_linux-balancer_tcp.ovpn
+++ b/linux/cstorm_linux-balancer_tcp.ovpn
@@ -9,7 +9,7 @@ remote linux-balancer.cryptostorm.nu 443 tcp
 remote linux-balancer.cryptostorm.org 443 tcp
 remote linux-balancer.cstorm.pw 443 tcp
 nobind
-compress
+compress lzo
 down-pre
 reneg-sec 0
 hand-window 17

--- a/linux/cstorm_linux-balancer_udp.ovpn
+++ b/linux/cstorm_linux-balancer_udp.ovpn
@@ -11,7 +11,7 @@ remote linux-balancer.cstorm.pw 443 udp
 explicit-exit-notify 3
 mssfix 1400
 nobind
-compress
+compress lzo
 down-pre
 reneg-sec 0
 hand-window 17

--- a/linux/cstorm_linux-balancer_udp.ovpn
+++ b/linux/cstorm_linux-balancer_udp.ovpn
@@ -11,19 +11,18 @@ remote linux-balancer.cstorm.pw 443 udp
 explicit-exit-notify 3
 mssfix 1400
 nobind
-comp-lzo
+compress
 down-pre
 reneg-sec 0
 hand-window 17
 verb 4
 mute 3
 auth-user-pass
-ns-cert-type server
+remote-cert-tls server
 auth SHA512
 cipher AES-256-CBC
 tls-cipher TLS-DHE-RSA-WITH-AES-256-CBC-SHA
 tls-client
-key-method 2
 ca ca.crt
 # specification & location of server-verification PKI materials
 # for details, see https://cryptostorm.org/pki

--- a/linux/cstorm_linux-canadaeast_tcp.ovpn
+++ b/linux/cstorm_linux-canadaeast_tcp.ovpn
@@ -9,19 +9,18 @@ remote linux-canadaeast.cryptostorm.nu 443 tcp
 remote linux-canadaeast.cryptostorm.org 443 tcp
 remote linux-canadaeast.cstorm.pw 443 tcp
 nobind
-comp-lzo
+compress
 down-pre
 reneg-sec 0
 hand-window 17
 verb 4
 mute 3
 auth-user-pass
-ns-cert-type server
+remote-cert-tls server
 auth SHA512
 cipher AES-256-CBC
 tls-cipher TLS-DHE-RSA-WITH-AES-256-CBC-SHA
 tls-client
-key-method 2
 ca ca.crt
 # specification & location of server-verification PKI materials
 # for details, see https://cryptostorm.org/pki

--- a/linux/cstorm_linux-canadaeast_tcp.ovpn
+++ b/linux/cstorm_linux-canadaeast_tcp.ovpn
@@ -9,7 +9,7 @@ remote linux-canadaeast.cryptostorm.nu 443 tcp
 remote linux-canadaeast.cryptostorm.org 443 tcp
 remote linux-canadaeast.cstorm.pw 443 tcp
 nobind
-compress
+compress lzo
 down-pre
 reneg-sec 0
 hand-window 17

--- a/linux/cstorm_linux-canadaeast_udp.ovpn
+++ b/linux/cstorm_linux-canadaeast_udp.ovpn
@@ -11,19 +11,18 @@ remote linux-canadaeast.cstorm.pw 443 udp
 explicit-exit-notify 3
 mssfix 1400
 nobind
-comp-lzo
+compress
 down-pre
 reneg-sec 0
 hand-window 17
 verb 4
 mute 3
 auth-user-pass
-ns-cert-type server
+remote-cert-tls server
 auth SHA512
 cipher AES-256-CBC
 tls-cipher TLS-DHE-RSA-WITH-AES-256-CBC-SHA
 tls-client
-key-method 2
 ca ca.crt
 # specification & location of server-verification PKI materials
 # for details, see https://cryptostorm.org/pki

--- a/linux/cstorm_linux-canadaeast_udp.ovpn
+++ b/linux/cstorm_linux-canadaeast_udp.ovpn
@@ -11,7 +11,7 @@ remote linux-canadaeast.cstorm.pw 443 udp
 explicit-exit-notify 3
 mssfix 1400
 nobind
-compress
+compress lzo
 down-pre
 reneg-sec 0
 hand-window 17

--- a/linux/cstorm_linux-canadawest_tcp.ovpn
+++ b/linux/cstorm_linux-canadawest_tcp.ovpn
@@ -9,19 +9,18 @@ remote linux-canadawest.cryptostorm.nu 443 tcp
 remote linux-canadawest.cryptostorm.org 443 tcp
 remote linux-canadawest.cstorm.pw 443 tcp
 nobind
-comp-lzo
+compress
 down-pre
 reneg-sec 0
 hand-window 17
 verb 4
 mute 3
 auth-user-pass
-ns-cert-type server
+remote-cert-tls server
 auth SHA512
 cipher AES-256-CBC
 tls-cipher TLS-DHE-RSA-WITH-AES-256-CBC-SHA
 tls-client
-key-method 2
 ca ca.crt
 # specification & location of server-verification PKI materials
 # for details, see https://cryptostorm.org/pki

--- a/linux/cstorm_linux-canadawest_tcp.ovpn
+++ b/linux/cstorm_linux-canadawest_tcp.ovpn
@@ -9,7 +9,7 @@ remote linux-canadawest.cryptostorm.nu 443 tcp
 remote linux-canadawest.cryptostorm.org 443 tcp
 remote linux-canadawest.cstorm.pw 443 tcp
 nobind
-compress
+compress lzo
 down-pre
 reneg-sec 0
 hand-window 17

--- a/linux/cstorm_linux-canadawest_udp.ovpn
+++ b/linux/cstorm_linux-canadawest_udp.ovpn
@@ -11,7 +11,7 @@ remote linux-canadawest.cstorm.pw 443 udp
 explicit-exit-notify 3
 mssfix 1400
 nobind
-compress
+compress lzo
 down-pre
 reneg-sec 0
 hand-window 17

--- a/linux/cstorm_linux-canadawest_udp.ovpn
+++ b/linux/cstorm_linux-canadawest_udp.ovpn
@@ -11,19 +11,18 @@ remote linux-canadawest.cstorm.pw 443 udp
 explicit-exit-notify 3
 mssfix 1400
 nobind
-comp-lzo
+compress
 down-pre
 reneg-sec 0
 hand-window 17
 verb 4
 mute 3
 auth-user-pass
-ns-cert-type server
+remote-cert-tls server
 auth SHA512
 cipher AES-256-CBC
 tls-cipher TLS-DHE-RSA-WITH-AES-256-CBC-SHA
 tls-client
-key-method 2
 ca ca.crt
 # specification & location of server-verification PKI materials
 # for details, see https://cryptostorm.org/pki

--- a/linux/cstorm_linux-denmark_tcp.ovpn
+++ b/linux/cstorm_linux-denmark_tcp.ovpn
@@ -9,19 +9,18 @@ remote linux-denmark.cryptostorm.nu 443 tcp
 remote linux-denmark.cryptostorm.org 443 tcp
 remote linux-denmark.cstorm.pw 443 tcp
 nobind
-comp-lzo
+compress
 down-pre
 reneg-sec 0
 hand-window 17
 verb 4
 mute 3
 auth-user-pass
-ns-cert-type server
+remote-cert-tls server
 auth SHA512
 cipher AES-256-CBC
 tls-cipher TLS-DHE-RSA-WITH-AES-256-CBC-SHA
 tls-client
-key-method 2
 ca ca.crt
 # specification & location of server-verification PKI materials
 # for details, see https://cryptostorm.org/pki

--- a/linux/cstorm_linux-denmark_tcp.ovpn
+++ b/linux/cstorm_linux-denmark_tcp.ovpn
@@ -9,7 +9,7 @@ remote linux-denmark.cryptostorm.nu 443 tcp
 remote linux-denmark.cryptostorm.org 443 tcp
 remote linux-denmark.cstorm.pw 443 tcp
 nobind
-compress
+compress lzo
 down-pre
 reneg-sec 0
 hand-window 17

--- a/linux/cstorm_linux-denmark_udp.ovpn
+++ b/linux/cstorm_linux-denmark_udp.ovpn
@@ -11,7 +11,7 @@ remote linux-denmark.cstorm.pw 443 udp
 explicit-exit-notify 3
 mssfix 1400
 nobind
-compress
+compress lzo
 down-pre
 reneg-sec 0
 hand-window 17

--- a/linux/cstorm_linux-denmark_udp.ovpn
+++ b/linux/cstorm_linux-denmark_udp.ovpn
@@ -11,19 +11,18 @@ remote linux-denmark.cstorm.pw 443 udp
 explicit-exit-notify 3
 mssfix 1400
 nobind
-comp-lzo
+compress
 down-pre
 reneg-sec 0
 hand-window 17
 verb 4
 mute 3
 auth-user-pass
-ns-cert-type server
+remote-cert-tls server
 auth SHA512
 cipher AES-256-CBC
 tls-cipher TLS-DHE-RSA-WITH-AES-256-CBC-SHA
 tls-client
-key-method 2
 ca ca.crt
 # specification & location of server-verification PKI materials
 # for details, see https://cryptostorm.org/pki

--- a/linux/cstorm_linux-dusseldorf_tcp.ovpn
+++ b/linux/cstorm_linux-dusseldorf_tcp.ovpn
@@ -9,19 +9,18 @@ remote linux-dusseldorf.cryptostorm.nu 443 tcp
 remote linux-dusseldorf.cryptostorm.org 443 tcp
 remote linux-dusseldorf.cstorm.pw 443 tcp
 nobind
-comp-lzo
+compress
 down-pre
 reneg-sec 0
 hand-window 17
 verb 4
 mute 3
 auth-user-pass
-ns-cert-type server
+remote-cert-tls server
 auth SHA512
 cipher AES-256-CBC
 tls-cipher TLS-DHE-RSA-WITH-AES-256-CBC-SHA
 tls-client
-key-method 2
 ca ca.crt
 # specification & location of server-verification PKI materials
 # for details, see https://cryptostorm.org/pki

--- a/linux/cstorm_linux-dusseldorf_tcp.ovpn
+++ b/linux/cstorm_linux-dusseldorf_tcp.ovpn
@@ -9,7 +9,7 @@ remote linux-dusseldorf.cryptostorm.nu 443 tcp
 remote linux-dusseldorf.cryptostorm.org 443 tcp
 remote linux-dusseldorf.cstorm.pw 443 tcp
 nobind
-compress
+compress lzo
 down-pre
 reneg-sec 0
 hand-window 17

--- a/linux/cstorm_linux-dusseldorf_udp.ovpn
+++ b/linux/cstorm_linux-dusseldorf_udp.ovpn
@@ -11,19 +11,18 @@ remote linux-dusseldorf.cstorm.pw 443 udp
 explicit-exit-notify 3
 mssfix 1400
 nobind
-comp-lzo
+compress
 down-pre
 reneg-sec 0
 hand-window 17
 verb 4
 mute 3
 auth-user-pass
-ns-cert-type server
+remote-cert-tls server
 auth SHA512
 cipher AES-256-CBC
 tls-cipher TLS-DHE-RSA-WITH-AES-256-CBC-SHA
 tls-client
-key-method 2
 ca ca.crt
 # specification & location of server-verification PKI materials
 # for details, see https://cryptostorm.org/pki

--- a/linux/cstorm_linux-dusseldorf_udp.ovpn
+++ b/linux/cstorm_linux-dusseldorf_udp.ovpn
@@ -11,7 +11,7 @@ remote linux-dusseldorf.cstorm.pw 443 udp
 explicit-exit-notify 3
 mssfix 1400
 nobind
-compress
+compress lzo
 down-pre
 reneg-sec 0
 hand-window 17

--- a/linux/cstorm_linux-england_tcp.ovpn
+++ b/linux/cstorm_linux-england_tcp.ovpn
@@ -9,7 +9,7 @@ remote linux-england.cryptostorm.nu 443 tcp
 remote linux-england.cryptostorm.org 443 tcp
 remote linux-england.cstorm.pw 443 tcp
 nobind
-compress
+compress lzo
 down-pre
 reneg-sec 0
 hand-window 17

--- a/linux/cstorm_linux-england_tcp.ovpn
+++ b/linux/cstorm_linux-england_tcp.ovpn
@@ -9,19 +9,18 @@ remote linux-england.cryptostorm.nu 443 tcp
 remote linux-england.cryptostorm.org 443 tcp
 remote linux-england.cstorm.pw 443 tcp
 nobind
-comp-lzo
+compress
 down-pre
 reneg-sec 0
 hand-window 17
 verb 4
 mute 3
 auth-user-pass
-ns-cert-type server
+remote-cert-tls server
 auth SHA512
 cipher AES-256-CBC
 tls-cipher TLS-DHE-RSA-WITH-AES-256-CBC-SHA
 tls-client
-key-method 2
 ca ca.crt
 # specification & location of server-verification PKI materials
 # for details, see https://cryptostorm.org/pki

--- a/linux/cstorm_linux-england_udp.ovpn
+++ b/linux/cstorm_linux-england_udp.ovpn
@@ -11,19 +11,18 @@ remote linux-england.cstorm.pw 443 udp
 explicit-exit-notify 3
 mssfix 1400
 nobind
-comp-lzo
+compress
 down-pre
 reneg-sec 0
 hand-window 17
 verb 4
 mute 3
 auth-user-pass
-ns-cert-type server
+remote-cert-tls server
 auth SHA512
 cipher AES-256-CBC
 tls-cipher TLS-DHE-RSA-WITH-AES-256-CBC-SHA
 tls-client
-key-method 2
 ca ca.crt
 # specification & location of server-verification PKI materials
 # for details, see https://cryptostorm.org/pki

--- a/linux/cstorm_linux-england_udp.ovpn
+++ b/linux/cstorm_linux-england_udp.ovpn
@@ -11,7 +11,7 @@ remote linux-england.cstorm.pw 443 udp
 explicit-exit-notify 3
 mssfix 1400
 nobind
-compress
+compress lzo
 down-pre
 reneg-sec 0
 hand-window 17

--- a/linux/cstorm_linux-finland_tcp.ovpn
+++ b/linux/cstorm_linux-finland_tcp.ovpn
@@ -9,7 +9,7 @@ remote linux-finland.cryptostorm.nu 443 tcp
 remote linux-finland.cryptostorm.org 443 tcp
 remote linux-finland.cstorm.pw 443 tcp
 nobind
-compress
+compress lzo
 down-pre
 reneg-sec 0
 hand-window 17

--- a/linux/cstorm_linux-finland_tcp.ovpn
+++ b/linux/cstorm_linux-finland_tcp.ovpn
@@ -9,19 +9,18 @@ remote linux-finland.cryptostorm.nu 443 tcp
 remote linux-finland.cryptostorm.org 443 tcp
 remote linux-finland.cstorm.pw 443 tcp
 nobind
-comp-lzo
+compress
 down-pre
 reneg-sec 0
 hand-window 17
 verb 4
 mute 3
 auth-user-pass
-ns-cert-type server
+remote-cert-tls server
 auth SHA512
 cipher AES-256-CBC
 tls-cipher TLS-DHE-RSA-WITH-AES-256-CBC-SHA
 tls-client
-key-method 2
 ca ca.crt
 # specification & location of server-verification PKI materials
 # for details, see https://cryptostorm.org/pki

--- a/linux/cstorm_linux-finland_udp.ovpn
+++ b/linux/cstorm_linux-finland_udp.ovpn
@@ -11,19 +11,18 @@ remote linux-finland.cstorm.pw 443 udp
 explicit-exit-notify 3
 mssfix 1400
 nobind
-comp-lzo
+compress
 down-pre
 reneg-sec 0
 hand-window 17
 verb 4
 mute 3
 auth-user-pass
-ns-cert-type server
+remote-cert-tls server
 auth SHA512
 cipher AES-256-CBC
 tls-cipher TLS-DHE-RSA-WITH-AES-256-CBC-SHA
 tls-client
-key-method 2
 ca ca.crt
 # specification & location of server-verification PKI materials
 # for details, see https://cryptostorm.org/pki

--- a/linux/cstorm_linux-finland_udp.ovpn
+++ b/linux/cstorm_linux-finland_udp.ovpn
@@ -11,7 +11,7 @@ remote linux-finland.cstorm.pw 443 udp
 explicit-exit-notify 3
 mssfix 1400
 nobind
-compress
+compress lzo
 down-pre
 reneg-sec 0
 hand-window 17

--- a/linux/cstorm_linux-frankfurt_tcp.ovpn
+++ b/linux/cstorm_linux-frankfurt_tcp.ovpn
@@ -9,7 +9,7 @@ remote linux-frankfurt.cryptostorm.nu 443 tcp
 remote linux-frankfurt.cryptostorm.org 443 tcp
 remote linux-frankfurt.cstorm.pw 443 tcp
 nobind
-compress
+compress lzo
 down-pre
 reneg-sec 0
 hand-window 17

--- a/linux/cstorm_linux-frankfurt_tcp.ovpn
+++ b/linux/cstorm_linux-frankfurt_tcp.ovpn
@@ -9,19 +9,18 @@ remote linux-frankfurt.cryptostorm.nu 443 tcp
 remote linux-frankfurt.cryptostorm.org 443 tcp
 remote linux-frankfurt.cstorm.pw 443 tcp
 nobind
-comp-lzo
+compress
 down-pre
 reneg-sec 0
 hand-window 17
 verb 4
 mute 3
 auth-user-pass
-ns-cert-type server
+remote-cert-tls server
 auth SHA512
 cipher AES-256-CBC
 tls-cipher TLS-DHE-RSA-WITH-AES-256-CBC-SHA
 tls-client
-key-method 2
 ca ca.crt
 # specification & location of server-verification PKI materials
 # for details, see https://cryptostorm.org/pki

--- a/linux/cstorm_linux-frankfurt_udp.ovpn
+++ b/linux/cstorm_linux-frankfurt_udp.ovpn
@@ -11,19 +11,18 @@ remote linux-frankfurt.cstorm.pw 443 udp
 explicit-exit-notify 3
 mssfix 1400
 nobind
-comp-lzo
+compress
 down-pre
 reneg-sec 0
 hand-window 17
 verb 4
 mute 3
 auth-user-pass
-ns-cert-type server
+remote-cert-tls server
 auth SHA512
 cipher AES-256-CBC
 tls-cipher TLS-DHE-RSA-WITH-AES-256-CBC-SHA
 tls-client
-key-method 2
 ca ca.crt
 # specification & location of server-verification PKI materials
 # for details, see https://cryptostorm.org/pki

--- a/linux/cstorm_linux-frankfurt_udp.ovpn
+++ b/linux/cstorm_linux-frankfurt_udp.ovpn
@@ -11,7 +11,7 @@ remote linux-frankfurt.cstorm.pw 443 udp
 explicit-exit-notify 3
 mssfix 1400
 nobind
-compress
+compress lzo
 down-pre
 reneg-sec 0
 hand-window 17

--- a/linux/cstorm_linux-latvia_tcp.ovpn
+++ b/linux/cstorm_linux-latvia_tcp.ovpn
@@ -9,7 +9,7 @@ remote linux-latvia.cryptostorm.nu 443 tcp
 remote linux-latvia.cryptostorm.org 443 tcp
 remote linux-latvia.cstorm.pw 443 tcp
 nobind
-compress
+compress lzo
 down-pre
 reneg-sec 0
 hand-window 17

--- a/linux/cstorm_linux-latvia_tcp.ovpn
+++ b/linux/cstorm_linux-latvia_tcp.ovpn
@@ -9,19 +9,18 @@ remote linux-latvia.cryptostorm.nu 443 tcp
 remote linux-latvia.cryptostorm.org 443 tcp
 remote linux-latvia.cstorm.pw 443 tcp
 nobind
-comp-lzo
+compress
 down-pre
 reneg-sec 0
 hand-window 17
 verb 4
 mute 3
 auth-user-pass
-ns-cert-type server
+remote-cert-tls server
 auth SHA512
 cipher AES-256-CBC
 tls-cipher TLS-DHE-RSA-WITH-AES-256-CBC-SHA
 tls-client
-key-method 2
 ca ca.crt
 # specification & location of server-verification PKI materials
 # for details, see https://cryptostorm.org/pki

--- a/linux/cstorm_linux-latvia_udp.ovpn
+++ b/linux/cstorm_linux-latvia_udp.ovpn
@@ -11,7 +11,7 @@ remote linux-latvia.cstorm.pw 443 udp
 explicit-exit-notify 3
 mssfix 1400
 nobind
-compress
+compress lzo
 down-pre
 reneg-sec 0
 hand-window 17

--- a/linux/cstorm_linux-latvia_udp.ovpn
+++ b/linux/cstorm_linux-latvia_udp.ovpn
@@ -11,19 +11,18 @@ remote linux-latvia.cstorm.pw 443 udp
 explicit-exit-notify 3
 mssfix 1400
 nobind
-comp-lzo
+compress
 down-pre
 reneg-sec 0
 hand-window 17
 verb 4
 mute 3
 auth-user-pass
-ns-cert-type server
+remote-cert-tls server
 auth SHA512
 cipher AES-256-CBC
 tls-cipher TLS-DHE-RSA-WITH-AES-256-CBC-SHA
 tls-client
-key-method 2
 ca ca.crt
 # specification & location of server-verification PKI materials
 # for details, see https://cryptostorm.org/pki

--- a/linux/cstorm_linux-lisbon_tcp.ovpn
+++ b/linux/cstorm_linux-lisbon_tcp.ovpn
@@ -9,19 +9,18 @@ remote linux-lisbon.cryptostorm.nu 443 tcp
 remote linux-lisbon.cryptostorm.org 443 tcp
 remote linux-lisbon.cstorm.pw 443 tcp
 nobind
-comp-lzo
+compress
 down-pre
 reneg-sec 0
 hand-window 17
 verb 4
 mute 3
 auth-user-pass
-ns-cert-type server
+remote-cert-tls server
 auth SHA512
 cipher AES-256-CBC
 tls-cipher TLS-DHE-RSA-WITH-AES-256-CBC-SHA
 tls-client
-key-method 2
 ca ca.crt
 # specification & location of server-verification PKI materials
 # for details, see https://cryptostorm.org/pki

--- a/linux/cstorm_linux-lisbon_tcp.ovpn
+++ b/linux/cstorm_linux-lisbon_tcp.ovpn
@@ -9,7 +9,7 @@ remote linux-lisbon.cryptostorm.nu 443 tcp
 remote linux-lisbon.cryptostorm.org 443 tcp
 remote linux-lisbon.cstorm.pw 443 tcp
 nobind
-compress
+compress lzo
 down-pre
 reneg-sec 0
 hand-window 17

--- a/linux/cstorm_linux-lisbon_udp.ovpn
+++ b/linux/cstorm_linux-lisbon_udp.ovpn
@@ -11,7 +11,7 @@ remote linux-lisbon.cstorm.pw 443 udp
 explicit-exit-notify 3
 mssfix 1400
 nobind
-compress
+compress lzo
 down-pre
 reneg-sec 0
 hand-window 17

--- a/linux/cstorm_linux-lisbon_udp.ovpn
+++ b/linux/cstorm_linux-lisbon_udp.ovpn
@@ -11,19 +11,18 @@ remote linux-lisbon.cstorm.pw 443 udp
 explicit-exit-notify 3
 mssfix 1400
 nobind
-comp-lzo
+compress
 down-pre
 reneg-sec 0
 hand-window 17
 verb 4
 mute 3
 auth-user-pass
-ns-cert-type server
+remote-cert-tls server
 auth SHA512
 cipher AES-256-CBC
 tls-cipher TLS-DHE-RSA-WITH-AES-256-CBC-SHA
 tls-client
-key-method 2
 ca ca.crt
 # specification & location of server-verification PKI materials
 # for details, see https://cryptostorm.org/pki

--- a/linux/cstorm_linux-lithuania_tcp.ovpn
+++ b/linux/cstorm_linux-lithuania_tcp.ovpn
@@ -9,7 +9,7 @@ remote linux-lithuania.cryptostorm.nu 443 tcp
 remote linux-lithuania.cryptostorm.org 443 tcp
 remote linux-lithuania.cstorm.pw 443 tcp
 nobind
-compress
+compress lzo
 down-pre
 reneg-sec 0
 hand-window 17

--- a/linux/cstorm_linux-lithuania_tcp.ovpn
+++ b/linux/cstorm_linux-lithuania_tcp.ovpn
@@ -9,19 +9,18 @@ remote linux-lithuania.cryptostorm.nu 443 tcp
 remote linux-lithuania.cryptostorm.org 443 tcp
 remote linux-lithuania.cstorm.pw 443 tcp
 nobind
-comp-lzo
+compress
 down-pre
 reneg-sec 0
 hand-window 17
 verb 4
 mute 3
 auth-user-pass
-ns-cert-type server
+remote-cert-tls server
 auth SHA512
 cipher AES-256-CBC
 tls-cipher TLS-DHE-RSA-WITH-AES-256-CBC-SHA
 tls-client
-key-method 2
 ca ca.crt
 # specification & location of server-verification PKI materials
 # for details, see https://cryptostorm.org/pki

--- a/linux/cstorm_linux-lithuania_udp.ovpn
+++ b/linux/cstorm_linux-lithuania_udp.ovpn
@@ -11,7 +11,7 @@ remote linux-lithuania.cstorm.pw 443 udp
 explicit-exit-notify 3
 mssfix 1400
 nobind
-compress
+compress lzo
 down-pre
 reneg-sec 0
 hand-window 17

--- a/linux/cstorm_linux-lithuania_udp.ovpn
+++ b/linux/cstorm_linux-lithuania_udp.ovpn
@@ -11,19 +11,18 @@ remote linux-lithuania.cstorm.pw 443 udp
 explicit-exit-notify 3
 mssfix 1400
 nobind
-comp-lzo
+compress
 down-pre
 reneg-sec 0
 hand-window 17
 verb 4
 mute 3
 auth-user-pass
-ns-cert-type server
+remote-cert-tls server
 auth SHA512
 cipher AES-256-CBC
 tls-cipher TLS-DHE-RSA-WITH-AES-256-CBC-SHA
 tls-client
-key-method 2
 ca ca.crt
 # specification & location of server-verification PKI materials
 # for details, see https://cryptostorm.org/pki

--- a/linux/cstorm_linux-moldova_tcp.ovpn
+++ b/linux/cstorm_linux-moldova_tcp.ovpn
@@ -9,7 +9,7 @@ remote linux-moldova.cryptostorm.nu 443 tcp
 remote linux-moldova.cryptostorm.org 443 tcp
 remote linux-moldova.cstorm.pw 443 tcp
 nobind
-compress
+compress lzo
 down-pre
 reneg-sec 0
 hand-window 17

--- a/linux/cstorm_linux-moldova_tcp.ovpn
+++ b/linux/cstorm_linux-moldova_tcp.ovpn
@@ -9,19 +9,18 @@ remote linux-moldova.cryptostorm.nu 443 tcp
 remote linux-moldova.cryptostorm.org 443 tcp
 remote linux-moldova.cstorm.pw 443 tcp
 nobind
-comp-lzo
+compress
 down-pre
 reneg-sec 0
 hand-window 17
 verb 4
 mute 3
 auth-user-pass
-ns-cert-type server
+remote-cert-tls server
 auth SHA512
 cipher AES-256-CBC
 tls-cipher TLS-DHE-RSA-WITH-AES-256-CBC-SHA
 tls-client
-key-method 2
 ca ca.crt
 # specification & location of server-verification PKI materials
 # for details, see https://cryptostorm.org/pki

--- a/linux/cstorm_linux-moldova_udp.ovpn
+++ b/linux/cstorm_linux-moldova_udp.ovpn
@@ -11,19 +11,18 @@ remote linux-moldova.cstorm.pw 443 udp
 explicit-exit-notify 3
 mssfix 1400
 nobind
-comp-lzo
+compress
 down-pre
 reneg-sec 0
 hand-window 17
 verb 4
 mute 3
 auth-user-pass
-ns-cert-type server
+remote-cert-tls server
 auth SHA512
 cipher AES-256-CBC
 tls-cipher TLS-DHE-RSA-WITH-AES-256-CBC-SHA
 tls-client
-key-method 2
 ca ca.crt
 # specification & location of server-verification PKI materials
 # for details, see https://cryptostorm.org/pki

--- a/linux/cstorm_linux-moldova_udp.ovpn
+++ b/linux/cstorm_linux-moldova_udp.ovpn
@@ -11,7 +11,7 @@ remote linux-moldova.cstorm.pw 443 udp
 explicit-exit-notify 3
 mssfix 1400
 nobind
-compress
+compress lzo
 down-pre
 reneg-sec 0
 hand-window 17

--- a/linux/cstorm_linux-netherlands_tcp.ovpn
+++ b/linux/cstorm_linux-netherlands_tcp.ovpn
@@ -9,7 +9,7 @@ remote linux-netherlands.cryptostorm.nu 443 tcp
 remote linux-netherlands.cryptostorm.org 443 tcp
 remote linux-netherlands.cstorm.pw 443 tcp
 nobind
-compress
+compress lzo
 down-pre
 reneg-sec 0
 hand-window 17

--- a/linux/cstorm_linux-netherlands_tcp.ovpn
+++ b/linux/cstorm_linux-netherlands_tcp.ovpn
@@ -9,19 +9,18 @@ remote linux-netherlands.cryptostorm.nu 443 tcp
 remote linux-netherlands.cryptostorm.org 443 tcp
 remote linux-netherlands.cstorm.pw 443 tcp
 nobind
-comp-lzo
+compress
 down-pre
 reneg-sec 0
 hand-window 17
 verb 4
 mute 3
 auth-user-pass
-ns-cert-type server
+remote-cert-tls server
 auth SHA512
 cipher AES-256-CBC
 tls-cipher TLS-DHE-RSA-WITH-AES-256-CBC-SHA
 tls-client
-key-method 2
 ca ca.crt
 # specification & location of server-verification PKI materials
 # for details, see https://cryptostorm.org/pki

--- a/linux/cstorm_linux-netherlands_udp.ovpn
+++ b/linux/cstorm_linux-netherlands_udp.ovpn
@@ -11,19 +11,18 @@ remote linux-netherlands.cstorm.pw 443 udp
 explicit-exit-notify 3
 mssfix 1400
 nobind
-comp-lzo
+compress
 down-pre
 reneg-sec 0
 hand-window 17
 verb 4
 mute 3
 auth-user-pass
-ns-cert-type server
+remote-cert-tls server
 auth SHA512
 cipher AES-256-CBC
 tls-cipher TLS-DHE-RSA-WITH-AES-256-CBC-SHA
 tls-client
-key-method 2
 ca ca.crt
 # specification & location of server-verification PKI materials
 # for details, see https://cryptostorm.org/pki

--- a/linux/cstorm_linux-netherlands_udp.ovpn
+++ b/linux/cstorm_linux-netherlands_udp.ovpn
@@ -11,7 +11,7 @@ remote linux-netherlands.cstorm.pw 443 udp
 explicit-exit-notify 3
 mssfix 1400
 nobind
-compress
+compress lzo
 down-pre
 reneg-sec 0
 hand-window 17

--- a/linux/cstorm_linux-paris_tcp.ovpn
+++ b/linux/cstorm_linux-paris_tcp.ovpn
@@ -9,19 +9,18 @@ remote linux-paris.cryptostorm.nu 443 tcp
 remote linux-paris.cryptostorm.org 443 tcp
 remote linux-paris.cstorm.pw 443 tcp
 nobind
-comp-lzo
+compress
 down-pre
 reneg-sec 0
 hand-window 17
 verb 4
 mute 3
 auth-user-pass
-ns-cert-type server
+remote-cert-tls server
 auth SHA512
 cipher AES-256-CBC
 tls-cipher TLS-DHE-RSA-WITH-AES-256-CBC-SHA
 tls-client
-key-method 2
 ca ca.crt
 # specification & location of server-verification PKI materials
 # for details, see https://cryptostorm.org/pki

--- a/linux/cstorm_linux-paris_tcp.ovpn
+++ b/linux/cstorm_linux-paris_tcp.ovpn
@@ -9,7 +9,7 @@ remote linux-paris.cryptostorm.nu 443 tcp
 remote linux-paris.cryptostorm.org 443 tcp
 remote linux-paris.cstorm.pw 443 tcp
 nobind
-compress
+compress lzo
 down-pre
 reneg-sec 0
 hand-window 17

--- a/linux/cstorm_linux-paris_udp.ovpn
+++ b/linux/cstorm_linux-paris_udp.ovpn
@@ -11,7 +11,7 @@ remote linux-paris.cstorm.pw 443 udp
 explicit-exit-notify 3
 mssfix 1400
 nobind
-compress
+compress lzo
 down-pre
 reneg-sec 0
 hand-window 17

--- a/linux/cstorm_linux-paris_udp.ovpn
+++ b/linux/cstorm_linux-paris_udp.ovpn
@@ -11,19 +11,18 @@ remote linux-paris.cstorm.pw 443 udp
 explicit-exit-notify 3
 mssfix 1400
 nobind
-comp-lzo
+compress
 down-pre
 reneg-sec 0
 hand-window 17
 verb 4
 mute 3
 auth-user-pass
-ns-cert-type server
+remote-cert-tls server
 auth SHA512
 cipher AES-256-CBC
 tls-cipher TLS-DHE-RSA-WITH-AES-256-CBC-SHA
 tls-client
-key-method 2
 ca ca.crt
 # specification & location of server-verification PKI materials
 # for details, see https://cryptostorm.org/pki

--- a/linux/cstorm_linux-poland_tcp.ovpn
+++ b/linux/cstorm_linux-poland_tcp.ovpn
@@ -9,19 +9,18 @@ remote linux-poland.cryptostorm.nu 443 tcp
 remote linux-poland.cryptostorm.org 443 tcp
 remote linux-poland.cstorm.pw 443 tcp
 nobind
-comp-lzo
+compress
 down-pre
 reneg-sec 0
 hand-window 17
 verb 4
 mute 3
 auth-user-pass
-ns-cert-type server
+remote-cert-tls server
 auth SHA512
 cipher AES-256-CBC
 tls-cipher TLS-DHE-RSA-WITH-AES-256-CBC-SHA
 tls-client
-key-method 2
 ca ca.crt
 # specification & location of server-verification PKI materials
 # for details, see https://cryptostorm.org/pki

--- a/linux/cstorm_linux-poland_tcp.ovpn
+++ b/linux/cstorm_linux-poland_tcp.ovpn
@@ -9,7 +9,7 @@ remote linux-poland.cryptostorm.nu 443 tcp
 remote linux-poland.cryptostorm.org 443 tcp
 remote linux-poland.cstorm.pw 443 tcp
 nobind
-compress
+compress lzo
 down-pre
 reneg-sec 0
 hand-window 17

--- a/linux/cstorm_linux-poland_udp.ovpn
+++ b/linux/cstorm_linux-poland_udp.ovpn
@@ -11,7 +11,7 @@ remote linux-poland.cstorm.pw 443 udp
 explicit-exit-notify 3
 mssfix 1400
 nobind
-compress
+compress lzo
 down-pre
 reneg-sec 0
 hand-window 17

--- a/linux/cstorm_linux-poland_udp.ovpn
+++ b/linux/cstorm_linux-poland_udp.ovpn
@@ -11,19 +11,18 @@ remote linux-poland.cstorm.pw 443 udp
 explicit-exit-notify 3
 mssfix 1400
 nobind
-comp-lzo
+compress
 down-pre
 reneg-sec 0
 hand-window 17
 verb 4
 mute 3
 auth-user-pass
-ns-cert-type server
+remote-cert-tls server
 auth SHA512
 cipher AES-256-CBC
 tls-cipher TLS-DHE-RSA-WITH-AES-256-CBC-SHA
 tls-client
-key-method 2
 ca ca.crt
 # specification & location of server-verification PKI materials
 # for details, see https://cryptostorm.org/pki

--- a/linux/cstorm_linux-rome_tcp.ovpn
+++ b/linux/cstorm_linux-rome_tcp.ovpn
@@ -9,7 +9,7 @@ remote linux-rome.cryptostorm.nu 443 tcp
 remote linux-rome.cryptostorm.org 443 tcp
 remote linux-rome.cstorm.pw 443 tcp
 nobind
-compress
+compress lzo
 down-pre
 reneg-sec 0
 hand-window 17

--- a/linux/cstorm_linux-rome_tcp.ovpn
+++ b/linux/cstorm_linux-rome_tcp.ovpn
@@ -9,19 +9,18 @@ remote linux-rome.cryptostorm.nu 443 tcp
 remote linux-rome.cryptostorm.org 443 tcp
 remote linux-rome.cstorm.pw 443 tcp
 nobind
-comp-lzo
+compress
 down-pre
 reneg-sec 0
 hand-window 17
 verb 4
 mute 3
 auth-user-pass
-ns-cert-type server
+remote-cert-tls server
 auth SHA512
 cipher AES-256-CBC
 tls-cipher TLS-DHE-RSA-WITH-AES-256-CBC-SHA
 tls-client
-key-method 2
 ca ca.crt
 # specification & location of server-verification PKI materials
 # for details, see https://cryptostorm.org/pki

--- a/linux/cstorm_linux-rome_udp.ovpn
+++ b/linux/cstorm_linux-rome_udp.ovpn
@@ -11,19 +11,18 @@ remote linux-rome.cstorm.pw 443 udp
 explicit-exit-notify 3
 mssfix 1400
 nobind
-comp-lzo
+compress
 down-pre
 reneg-sec 0
 hand-window 17
 verb 4
 mute 3
 auth-user-pass
-ns-cert-type server
+remote-cert-tls server
 auth SHA512
 cipher AES-256-CBC
 tls-cipher TLS-DHE-RSA-WITH-AES-256-CBC-SHA
 tls-client
-key-method 2
 ca ca.crt
 # specification & location of server-verification PKI materials
 # for details, see https://cryptostorm.org/pki

--- a/linux/cstorm_linux-rome_udp.ovpn
+++ b/linux/cstorm_linux-rome_udp.ovpn
@@ -11,7 +11,7 @@ remote linux-rome.cstorm.pw 443 udp
 explicit-exit-notify 3
 mssfix 1400
 nobind
-compress
+compress lzo
 down-pre
 reneg-sec 0
 hand-window 17

--- a/linux/cstorm_linux-spain_tcp.ovpn
+++ b/linux/cstorm_linux-spain_tcp.ovpn
@@ -9,19 +9,18 @@ remote linux-spain.cryptostorm.nu 443 tcp
 remote linux-spain.cryptostorm.org 443 tcp
 remote linux-spain.cstorm.pw 443 tcp
 nobind
-comp-lzo
+compress
 down-pre
 reneg-sec 0
 hand-window 17
 verb 4
 mute 3
 auth-user-pass
-ns-cert-type server
+remote-cert-tls server
 auth SHA512
 cipher AES-256-CBC
 tls-cipher TLS-DHE-RSA-WITH-AES-256-CBC-SHA
 tls-client
-key-method 2
 ca ca.crt
 # specification & location of server-verification PKI materials
 # for details, see https://cryptostorm.org/pki

--- a/linux/cstorm_linux-spain_tcp.ovpn
+++ b/linux/cstorm_linux-spain_tcp.ovpn
@@ -9,7 +9,7 @@ remote linux-spain.cryptostorm.nu 443 tcp
 remote linux-spain.cryptostorm.org 443 tcp
 remote linux-spain.cstorm.pw 443 tcp
 nobind
-compress
+compress lzo
 down-pre
 reneg-sec 0
 hand-window 17

--- a/linux/cstorm_linux-spain_udp.ovpn
+++ b/linux/cstorm_linux-spain_udp.ovpn
@@ -11,7 +11,7 @@ remote linux-spain.cstorm.pw 443 udp
 explicit-exit-notify 3
 mssfix 1400
 nobind
-compress
+compress lzo
 down-pre
 reneg-sec 0
 hand-window 17

--- a/linux/cstorm_linux-spain_udp.ovpn
+++ b/linux/cstorm_linux-spain_udp.ovpn
@@ -11,19 +11,18 @@ remote linux-spain.cstorm.pw 443 udp
 explicit-exit-notify 3
 mssfix 1400
 nobind
-comp-lzo
+compress
 down-pre
 reneg-sec 0
 hand-window 17
 verb 4
 mute 3
 auth-user-pass
-ns-cert-type server
+remote-cert-tls server
 auth SHA512
 cipher AES-256-CBC
 tls-cipher TLS-DHE-RSA-WITH-AES-256-CBC-SHA
 tls-client
-key-method 2
 ca ca.crt
 # specification & location of server-verification PKI materials
 # for details, see https://cryptostorm.org/pki

--- a/linux/cstorm_linux-switzerland_tcp.ovpn
+++ b/linux/cstorm_linux-switzerland_tcp.ovpn
@@ -9,7 +9,7 @@ remote linux-switzerland.cryptostorm.nu 443 tcp
 remote linux-switzerland.cryptostorm.org 443 tcp
 remote linux-switzerland.cstorm.pw 443 tcp
 nobind
-compress
+compress lzo
 down-pre
 reneg-sec 0
 hand-window 17

--- a/linux/cstorm_linux-switzerland_tcp.ovpn
+++ b/linux/cstorm_linux-switzerland_tcp.ovpn
@@ -9,19 +9,18 @@ remote linux-switzerland.cryptostorm.nu 443 tcp
 remote linux-switzerland.cryptostorm.org 443 tcp
 remote linux-switzerland.cstorm.pw 443 tcp
 nobind
-comp-lzo
+compress
 down-pre
 reneg-sec 0
 hand-window 17
 verb 4
 mute 3
 auth-user-pass
-ns-cert-type server
+remote-cert-tls server
 auth SHA512
 cipher AES-256-CBC
 tls-cipher TLS-DHE-RSA-WITH-AES-256-CBC-SHA
 tls-client
-key-method 2
 ca ca.crt
 # specification & location of server-verification PKI materials
 # for details, see https://cryptostorm.org/pki

--- a/linux/cstorm_linux-switzerland_udp.ovpn
+++ b/linux/cstorm_linux-switzerland_udp.ovpn
@@ -11,19 +11,18 @@ remote linux-switzerland.cstorm.pw 443 udp
 explicit-exit-notify 3
 mssfix 1400
 nobind
-comp-lzo
+compress
 down-pre
 reneg-sec 0
 hand-window 17
 verb 4
 mute 3
 auth-user-pass
-ns-cert-type server
+remote-cert-tls server
 auth SHA512
 cipher AES-256-CBC
 tls-cipher TLS-DHE-RSA-WITH-AES-256-CBC-SHA
 tls-client
-key-method 2
 ca ca.crt
 # specification & location of server-verification PKI materials
 # for details, see https://cryptostorm.org/pki

--- a/linux/cstorm_linux-switzerland_udp.ovpn
+++ b/linux/cstorm_linux-switzerland_udp.ovpn
@@ -11,7 +11,7 @@ remote linux-switzerland.cstorm.pw 443 udp
 explicit-exit-notify 3
 mssfix 1400
 nobind
-compress
+compress lzo
 down-pre
 reneg-sec 0
 hand-window 17

--- a/linux/cstorm_linux-useast_tcp.ovpn
+++ b/linux/cstorm_linux-useast_tcp.ovpn
@@ -9,19 +9,18 @@ remote linux-useast.cryptostorm.nu 443 tcp
 remote linux-useast.cryptostorm.org 443 tcp
 remote linux-useast.cstorm.pw 443 tcp
 nobind
-comp-lzo
+compress
 down-pre
 reneg-sec 0
 hand-window 17
 verb 4
 mute 3
 auth-user-pass
-ns-cert-type server
+remote-cert-tls server
 auth SHA512
 cipher AES-256-CBC
 tls-cipher TLS-DHE-RSA-WITH-AES-256-CBC-SHA
 tls-client
-key-method 2
 ca ca.crt
 # specification & location of server-verification PKI materials
 # for details, see https://cryptostorm.org/pki

--- a/linux/cstorm_linux-useast_tcp.ovpn
+++ b/linux/cstorm_linux-useast_tcp.ovpn
@@ -9,7 +9,7 @@ remote linux-useast.cryptostorm.nu 443 tcp
 remote linux-useast.cryptostorm.org 443 tcp
 remote linux-useast.cstorm.pw 443 tcp
 nobind
-compress
+compress lzo
 down-pre
 reneg-sec 0
 hand-window 17

--- a/linux/cstorm_linux-useast_udp.ovpn
+++ b/linux/cstorm_linux-useast_udp.ovpn
@@ -11,7 +11,7 @@ remote linux-useast.cstorm.pw 443 udp
 explicit-exit-notify 3
 mssfix 1400
 nobind
-compress
+compress lzo
 down-pre
 reneg-sec 0
 hand-window 17

--- a/linux/cstorm_linux-useast_udp.ovpn
+++ b/linux/cstorm_linux-useast_udp.ovpn
@@ -11,19 +11,18 @@ remote linux-useast.cstorm.pw 443 udp
 explicit-exit-notify 3
 mssfix 1400
 nobind
-comp-lzo
+compress
 down-pre
 reneg-sec 0
 hand-window 17
 verb 4
 mute 3
 auth-user-pass
-ns-cert-type server
+remote-cert-tls server
 auth SHA512
 cipher AES-256-CBC
 tls-cipher TLS-DHE-RSA-WITH-AES-256-CBC-SHA
 tls-client
-key-method 2
 ca ca.crt
 # specification & location of server-verification PKI materials
 # for details, see https://cryptostorm.org/pki

--- a/linux/cstorm_linux-usnorth_tcp.ovpn
+++ b/linux/cstorm_linux-usnorth_tcp.ovpn
@@ -9,7 +9,7 @@ remote linux-usnorth.cryptostorm.nu 443 tcp
 remote linux-usnorth.cryptostorm.org 443 tcp
 remote linux-usnorth.cstorm.pw 443 tcp
 nobind
-compress
+compress lzo
 down-pre
 reneg-sec 0
 hand-window 17

--- a/linux/cstorm_linux-usnorth_tcp.ovpn
+++ b/linux/cstorm_linux-usnorth_tcp.ovpn
@@ -9,19 +9,18 @@ remote linux-usnorth.cryptostorm.nu 443 tcp
 remote linux-usnorth.cryptostorm.org 443 tcp
 remote linux-usnorth.cstorm.pw 443 tcp
 nobind
-comp-lzo
+compress
 down-pre
 reneg-sec 0
 hand-window 17
 verb 4
 mute 3
 auth-user-pass
-ns-cert-type server
+remote-cert-tls server
 auth SHA512
 cipher AES-256-CBC
 tls-cipher TLS-DHE-RSA-WITH-AES-256-CBC-SHA
 tls-client
-key-method 2
 ca ca.crt
 # specification & location of server-verification PKI materials
 # for details, see https://cryptostorm.org/pki

--- a/linux/cstorm_linux-usnorth_udp.ovpn
+++ b/linux/cstorm_linux-usnorth_udp.ovpn
@@ -11,7 +11,7 @@ remote linux-usnorth.cstorm.pw 443 udp
 explicit-exit-notify 3
 mssfix 1400
 nobind
-compress
+compress lzo
 down-pre
 reneg-sec 0
 hand-window 17

--- a/linux/cstorm_linux-usnorth_udp.ovpn
+++ b/linux/cstorm_linux-usnorth_udp.ovpn
@@ -11,19 +11,18 @@ remote linux-usnorth.cstorm.pw 443 udp
 explicit-exit-notify 3
 mssfix 1400
 nobind
-comp-lzo
+compress
 down-pre
 reneg-sec 0
 hand-window 17
 verb 4
 mute 3
 auth-user-pass
-ns-cert-type server
+remote-cert-tls server
 auth SHA512
 cipher AES-256-CBC
 tls-cipher TLS-DHE-RSA-WITH-AES-256-CBC-SHA
 tls-client
-key-method 2
 ca ca.crt
 # specification & location of server-verification PKI materials
 # for details, see https://cryptostorm.org/pki

--- a/linux/cstorm_linux-ussouth_tcp.ovpn
+++ b/linux/cstorm_linux-ussouth_tcp.ovpn
@@ -9,7 +9,7 @@ remote linux-ussouth.cryptostorm.nu 443 tcp
 remote linux-ussouth.cryptostorm.org 443 tcp
 remote linux-ussouth.cstorm.pw 443 tcp
 nobind
-compress
+compress lzo
 down-pre
 reneg-sec 0
 hand-window 17

--- a/linux/cstorm_linux-ussouth_tcp.ovpn
+++ b/linux/cstorm_linux-ussouth_tcp.ovpn
@@ -9,19 +9,18 @@ remote linux-ussouth.cryptostorm.nu 443 tcp
 remote linux-ussouth.cryptostorm.org 443 tcp
 remote linux-ussouth.cstorm.pw 443 tcp
 nobind
-comp-lzo
+compress
 down-pre
 reneg-sec 0
 hand-window 17
 verb 4
 mute 3
 auth-user-pass
-ns-cert-type server
+remote-cert-tls server
 auth SHA512
 cipher AES-256-CBC
 tls-cipher TLS-DHE-RSA-WITH-AES-256-CBC-SHA
 tls-client
-key-method 2
 ca ca.crt
 # specification & location of server-verification PKI materials
 # for details, see https://cryptostorm.org/pki

--- a/linux/cstorm_linux-ussouth_udp.ovpn
+++ b/linux/cstorm_linux-ussouth_udp.ovpn
@@ -11,7 +11,7 @@ remote linux-ussouth.cstorm.pw 443 udp
 explicit-exit-notify 3
 mssfix 1400
 nobind
-compress
+compress lzo
 down-pre
 reneg-sec 0
 hand-window 17

--- a/linux/cstorm_linux-ussouth_udp.ovpn
+++ b/linux/cstorm_linux-ussouth_udp.ovpn
@@ -11,19 +11,18 @@ remote linux-ussouth.cstorm.pw 443 udp
 explicit-exit-notify 3
 mssfix 1400
 nobind
-comp-lzo
+compress
 down-pre
 reneg-sec 0
 hand-window 17
 verb 4
 mute 3
 auth-user-pass
-ns-cert-type server
+remote-cert-tls server
 auth SHA512
 cipher AES-256-CBC
 tls-cipher TLS-DHE-RSA-WITH-AES-256-CBC-SHA
 tls-client
-key-method 2
 ca ca.crt
 # specification & location of server-verification PKI materials
 # for details, see https://cryptostorm.org/pki

--- a/linux/cstorm_linux-uswest_tcp.ovpn
+++ b/linux/cstorm_linux-uswest_tcp.ovpn
@@ -9,19 +9,18 @@ remote linux-uswest.cryptostorm.nu 443 tcp
 remote linux-uswest.cryptostorm.org 443 tcp
 remote linux-uswest.cstorm.pw 443 tcp
 nobind
-comp-lzo
+compress
 down-pre
 reneg-sec 0
 hand-window 17
 verb 4
 mute 3
 auth-user-pass
-ns-cert-type server
+remote-cert-tls server
 auth SHA512
 cipher AES-256-CBC
 tls-cipher TLS-DHE-RSA-WITH-AES-256-CBC-SHA
 tls-client
-key-method 2
 ca ca.crt
 # specification & location of server-verification PKI materials
 # for details, see https://cryptostorm.org/pki

--- a/linux/cstorm_linux-uswest_tcp.ovpn
+++ b/linux/cstorm_linux-uswest_tcp.ovpn
@@ -9,7 +9,7 @@ remote linux-uswest.cryptostorm.nu 443 tcp
 remote linux-uswest.cryptostorm.org 443 tcp
 remote linux-uswest.cstorm.pw 443 tcp
 nobind
-compress
+compress lzo
 down-pre
 reneg-sec 0
 hand-window 17

--- a/linux/cstorm_linux-uswest_udp.ovpn
+++ b/linux/cstorm_linux-uswest_udp.ovpn
@@ -11,7 +11,7 @@ remote linux-uswest.cstorm.pw 443 udp
 explicit-exit-notify 3
 mssfix 1400
 nobind
-compress
+compress lzo
 down-pre
 reneg-sec 0
 hand-window 17

--- a/linux/cstorm_linux-uswest_udp.ovpn
+++ b/linux/cstorm_linux-uswest_udp.ovpn
@@ -11,19 +11,18 @@ remote linux-uswest.cstorm.pw 443 udp
 explicit-exit-notify 3
 mssfix 1400
 nobind
-comp-lzo
+compress
 down-pre
 reneg-sec 0
 hand-window 17
 verb 4
 mute 3
 auth-user-pass
-ns-cert-type server
+remote-cert-tls server
 auth SHA512
 cipher AES-256-CBC
 tls-cipher TLS-DHE-RSA-WITH-AES-256-CBC-SHA
 tls-client
-key-method 2
 ca ca.crt
 # specification & location of server-verification PKI materials
 # for details, see https://cryptostorm.org/pki

--- a/mac/Cryptofree_mac.ovpn
+++ b/mac/Cryptofree_mac.ovpn
@@ -11,7 +11,7 @@ remote linux-cryptofree.cryptostorm.org 443 udp
 remote linux-cryptofree.cryptokens.ca 443 udp
 remote linux-cryptofree.cstorm.pw 443 udp
 remote linux-cryptofree.cryptostorm.nu 443 udp
-comp-lzo
+compress
 down-pre
 allow-pull-fqdn
 explicit-exit-notify 3
@@ -50,13 +50,12 @@ U33KzBqGs8r3UEIMWXuIGc6eXOm2Br08iFgOsUPGqp1ulvD52pFH1o1vT21v3aXl
 D9Ier/83JLMnBGctT1Kzs9OP/U0=
 -----END CERTIFICATE-----
 </ca>
-ns-cert-type server
+remote-cert-tls server
 auth SHA512
 cipher AES-256-CBC
 replay-window 128 30
 tls-cipher TLS-DHE-RSA-WITH-AES-256-CBC-SHA
 tls-client
-key-method 2
 #log devnull.txt
 #verb 0
 #mute 1

--- a/mac/Cryptofree_mac.ovpn
+++ b/mac/Cryptofree_mac.ovpn
@@ -11,7 +11,7 @@ remote linux-cryptofree.cryptostorm.org 443 udp
 remote linux-cryptofree.cryptokens.ca 443 udp
 remote linux-cryptofree.cstorm.pw 443 udp
 remote linux-cryptofree.cryptostorm.nu 443 udp
-compress
+compress lzo
 down-pre
 allow-pull-fqdn
 explicit-exit-notify 3

--- a/mac/cstorm_Balancer.ovpn
+++ b/mac/cstorm_Balancer.ovpn
@@ -12,19 +12,18 @@ remote linux-balancer.cstorm.pw 443 udp
 explicit-exit-notify 3
 mssfix 1400
 nobind
-comp-lzo
+compress
 down-pre
 reneg-sec 0
 hand-window 17
 verb 4
 mute 3
 auth-user-pass
-ns-cert-type server
+remote-cert-tls server
 auth SHA512
 cipher AES-256-CBC
 tls-cipher TLS-DHE-RSA-WITH-AES-256-CBC-SHA
 tls-client
-key-method 2
 <ca>
 -----BEGIN CERTIFICATE-----
 MIIFIDCCBAigAwIBAgIJAKekpGXxXvhbMA0GCSqGSIb3DQEBCwUAMIG6MQswCQYD

--- a/mac/cstorm_Balancer.ovpn
+++ b/mac/cstorm_Balancer.ovpn
@@ -12,7 +12,7 @@ remote linux-balancer.cstorm.pw 443 udp
 explicit-exit-notify 3
 mssfix 1400
 nobind
-compress
+compress lzo
 down-pre
 reneg-sec 0
 hand-window 17

--- a/mac/cstorm_Canadaeast.ovpn
+++ b/mac/cstorm_Canadaeast.ovpn
@@ -12,19 +12,18 @@ remote linux-canadaeast.cstorm.pw 443 udp
 explicit-exit-notify 3
 mssfix 1400
 nobind
-comp-lzo
+compress
 down-pre
 reneg-sec 0
 hand-window 17
 verb 4
 mute 3
 auth-user-pass
-ns-cert-type server
+remote-cert-tls server
 auth SHA512
 cipher AES-256-CBC
 tls-cipher TLS-DHE-RSA-WITH-AES-256-CBC-SHA
 tls-client
-key-method 2
 <ca>
 -----BEGIN CERTIFICATE-----
 MIIFIDCCBAigAwIBAgIJAKekpGXxXvhbMA0GCSqGSIb3DQEBCwUAMIG6MQswCQYD

--- a/mac/cstorm_Canadaeast.ovpn
+++ b/mac/cstorm_Canadaeast.ovpn
@@ -12,7 +12,7 @@ remote linux-canadaeast.cstorm.pw 443 udp
 explicit-exit-notify 3
 mssfix 1400
 nobind
-compress
+compress lzo
 down-pre
 reneg-sec 0
 hand-window 17

--- a/mac/cstorm_Canadawest.ovpn
+++ b/mac/cstorm_Canadawest.ovpn
@@ -12,19 +12,18 @@ remote linux-canadawest.cstorm.pw 443 udp
 explicit-exit-notify 3
 mssfix 1400
 nobind
-comp-lzo
+compress
 down-pre
 reneg-sec 0
 hand-window 17
 verb 4
 mute 3
 auth-user-pass
-ns-cert-type server
+remote-cert-tls server
 auth SHA512
 cipher AES-256-CBC
 tls-cipher TLS-DHE-RSA-WITH-AES-256-CBC-SHA
 tls-client
-key-method 2
 <ca>
 -----BEGIN CERTIFICATE-----
 MIIFIDCCBAigAwIBAgIJAKekpGXxXvhbMA0GCSqGSIb3DQEBCwUAMIG6MQswCQYD

--- a/mac/cstorm_Canadawest.ovpn
+++ b/mac/cstorm_Canadawest.ovpn
@@ -12,7 +12,7 @@ remote linux-canadawest.cstorm.pw 443 udp
 explicit-exit-notify 3
 mssfix 1400
 nobind
-compress
+compress lzo
 down-pre
 reneg-sec 0
 hand-window 17

--- a/mac/cstorm_Denmark.ovpn
+++ b/mac/cstorm_Denmark.ovpn
@@ -12,19 +12,18 @@ remote linux-denmark.cstorm.pw 443 udp
 explicit-exit-notify 3
 mssfix 1400
 nobind
-comp-lzo
+compress
 down-pre
 reneg-sec 0
 hand-window 17
 verb 4
 mute 3
 auth-user-pass
-ns-cert-type server
+remote-cert-tls server
 auth SHA512
 cipher AES-256-CBC
 tls-cipher TLS-DHE-RSA-WITH-AES-256-CBC-SHA
 tls-client
-key-method 2
 <ca>
 -----BEGIN CERTIFICATE-----
 MIIFIDCCBAigAwIBAgIJAKekpGXxXvhbMA0GCSqGSIb3DQEBCwUAMIG6MQswCQYD

--- a/mac/cstorm_Denmark.ovpn
+++ b/mac/cstorm_Denmark.ovpn
@@ -12,7 +12,7 @@ remote linux-denmark.cstorm.pw 443 udp
 explicit-exit-notify 3
 mssfix 1400
 nobind
-compress
+compress lzo
 down-pre
 reneg-sec 0
 hand-window 17

--- a/mac/cstorm_Dusseldorf.ovpn
+++ b/mac/cstorm_Dusseldorf.ovpn
@@ -12,7 +12,7 @@ remote linux-dusseldorf.cstorm.pw 443 udp
 explicit-exit-notify 3
 mssfix 1400
 nobind
-compress
+compress lzo
 down-pre
 reneg-sec 0
 hand-window 17

--- a/mac/cstorm_Dusseldorf.ovpn
+++ b/mac/cstorm_Dusseldorf.ovpn
@@ -12,19 +12,18 @@ remote linux-dusseldorf.cstorm.pw 443 udp
 explicit-exit-notify 3
 mssfix 1400
 nobind
-comp-lzo
+compress
 down-pre
 reneg-sec 0
 hand-window 17
 verb 4
 mute 3
 auth-user-pass
-ns-cert-type server
+remote-cert-tls server
 auth SHA512
 cipher AES-256-CBC
 tls-cipher TLS-DHE-RSA-WITH-AES-256-CBC-SHA
 tls-client
-key-method 2
 <ca>
 -----BEGIN CERTIFICATE-----
 MIIFIDCCBAigAwIBAgIJAKekpGXxXvhbMA0GCSqGSIb3DQEBCwUAMIG6MQswCQYD

--- a/mac/cstorm_England.ovpn
+++ b/mac/cstorm_England.ovpn
@@ -12,19 +12,18 @@ remote linux-england.cstorm.pw 443 udp
 explicit-exit-notify 3
 mssfix 1400
 nobind
-comp-lzo
+compress
 down-pre
 reneg-sec 0
 hand-window 17
 verb 4
 mute 3
 auth-user-pass
-ns-cert-type server
+remote-cert-tls server
 auth SHA512
 cipher AES-256-CBC
 tls-cipher TLS-DHE-RSA-WITH-AES-256-CBC-SHA
 tls-client
-key-method 2
 <ca>
 -----BEGIN CERTIFICATE-----
 MIIFIDCCBAigAwIBAgIJAKekpGXxXvhbMA0GCSqGSIb3DQEBCwUAMIG6MQswCQYD

--- a/mac/cstorm_England.ovpn
+++ b/mac/cstorm_England.ovpn
@@ -12,7 +12,7 @@ remote linux-england.cstorm.pw 443 udp
 explicit-exit-notify 3
 mssfix 1400
 nobind
-compress
+compress lzo
 down-pre
 reneg-sec 0
 hand-window 17

--- a/mac/cstorm_Finland.ovpn
+++ b/mac/cstorm_Finland.ovpn
@@ -12,19 +12,18 @@ remote linux-finland.cstorm.pw 443 udp
 explicit-exit-notify 3
 mssfix 1400
 nobind
-comp-lzo
+compress
 down-pre
 reneg-sec 0
 hand-window 17
 verb 4
 mute 3
 auth-user-pass
-ns-cert-type server
+remote-cert-tls server
 auth SHA512
 cipher AES-256-CBC
 tls-cipher TLS-DHE-RSA-WITH-AES-256-CBC-SHA
 tls-client
-key-method 2
 <ca>
 -----BEGIN CERTIFICATE-----
 MIIFIDCCBAigAwIBAgIJAKekpGXxXvhbMA0GCSqGSIb3DQEBCwUAMIG6MQswCQYD

--- a/mac/cstorm_Finland.ovpn
+++ b/mac/cstorm_Finland.ovpn
@@ -12,7 +12,7 @@ remote linux-finland.cstorm.pw 443 udp
 explicit-exit-notify 3
 mssfix 1400
 nobind
-compress
+compress lzo
 down-pre
 reneg-sec 0
 hand-window 17

--- a/mac/cstorm_Frankfurt.ovpn
+++ b/mac/cstorm_Frankfurt.ovpn
@@ -12,7 +12,7 @@ remote linux-frankfurt.cstorm.pw 443 udp
 explicit-exit-notify 3
 mssfix 1400
 nobind
-compress
+compress lzo
 down-pre
 reneg-sec 0
 hand-window 17

--- a/mac/cstorm_Frankfurt.ovpn
+++ b/mac/cstorm_Frankfurt.ovpn
@@ -12,19 +12,18 @@ remote linux-frankfurt.cstorm.pw 443 udp
 explicit-exit-notify 3
 mssfix 1400
 nobind
-comp-lzo
+compress
 down-pre
 reneg-sec 0
 hand-window 17
 verb 4
 mute 3
 auth-user-pass
-ns-cert-type server
+remote-cert-tls server
 auth SHA512
 cipher AES-256-CBC
 tls-cipher TLS-DHE-RSA-WITH-AES-256-CBC-SHA
 tls-client
-key-method 2
 <ca>
 -----BEGIN CERTIFICATE-----
 MIIFIDCCBAigAwIBAgIJAKekpGXxXvhbMA0GCSqGSIb3DQEBCwUAMIG6MQswCQYD

--- a/mac/cstorm_Latvia.ovpn
+++ b/mac/cstorm_Latvia.ovpn
@@ -12,19 +12,18 @@ remote linux-latvia.cstorm.pw 443 udp
 explicit-exit-notify 3
 mssfix 1400
 nobind
-comp-lzo
+compress
 down-pre
 reneg-sec 0
 hand-window 17
 verb 4
 mute 3
 auth-user-pass
-ns-cert-type server
+remote-cert-tls server
 auth SHA512
 cipher AES-256-CBC
 tls-cipher TLS-DHE-RSA-WITH-AES-256-CBC-SHA
 tls-client
-key-method 2
 <ca>
 -----BEGIN CERTIFICATE-----
 MIIFIDCCBAigAwIBAgIJAKekpGXxXvhbMA0GCSqGSIb3DQEBCwUAMIG6MQswCQYD

--- a/mac/cstorm_Latvia.ovpn
+++ b/mac/cstorm_Latvia.ovpn
@@ -12,7 +12,7 @@ remote linux-latvia.cstorm.pw 443 udp
 explicit-exit-notify 3
 mssfix 1400
 nobind
-compress
+compress lzo
 down-pre
 reneg-sec 0
 hand-window 17

--- a/mac/cstorm_Lisbon.ovpn
+++ b/mac/cstorm_Lisbon.ovpn
@@ -12,19 +12,18 @@ remote linux-lisbon.cstorm.pw 443 udp
 explicit-exit-notify 3
 mssfix 1400
 nobind
-comp-lzo
+compress
 down-pre
 reneg-sec 0
 hand-window 17
 verb 4
 mute 3
 auth-user-pass
-ns-cert-type server
+remote-cert-tls server
 auth SHA512
 cipher AES-256-CBC
 tls-cipher TLS-DHE-RSA-WITH-AES-256-CBC-SHA
 tls-client
-key-method 2
 <ca>
 -----BEGIN CERTIFICATE-----
 MIIFIDCCBAigAwIBAgIJAKekpGXxXvhbMA0GCSqGSIb3DQEBCwUAMIG6MQswCQYD

--- a/mac/cstorm_Lisbon.ovpn
+++ b/mac/cstorm_Lisbon.ovpn
@@ -12,7 +12,7 @@ remote linux-lisbon.cstorm.pw 443 udp
 explicit-exit-notify 3
 mssfix 1400
 nobind
-compress
+compress lzo
 down-pre
 reneg-sec 0
 hand-window 17

--- a/mac/cstorm_Lithuania.ovpn
+++ b/mac/cstorm_Lithuania.ovpn
@@ -12,7 +12,7 @@ remote linux-lithuania.cstorm.pw 443 udp
 explicit-exit-notify 3
 mssfix 1400
 nobind
-compress
+compress lzo
 down-pre
 reneg-sec 0
 hand-window 17

--- a/mac/cstorm_Lithuania.ovpn
+++ b/mac/cstorm_Lithuania.ovpn
@@ -12,19 +12,18 @@ remote linux-lithuania.cstorm.pw 443 udp
 explicit-exit-notify 3
 mssfix 1400
 nobind
-comp-lzo
+compress
 down-pre
 reneg-sec 0
 hand-window 17
 verb 4
 mute 3
 auth-user-pass
-ns-cert-type server
+remote-cert-tls server
 auth SHA512
 cipher AES-256-CBC
 tls-cipher TLS-DHE-RSA-WITH-AES-256-CBC-SHA
 tls-client
-key-method 2
 <ca>
 -----BEGIN CERTIFICATE-----
 MIIFIDCCBAigAwIBAgIJAKekpGXxXvhbMA0GCSqGSIb3DQEBCwUAMIG6MQswCQYD

--- a/mac/cstorm_Moldova.ovpn
+++ b/mac/cstorm_Moldova.ovpn
@@ -12,7 +12,7 @@ remote linux-moldova.cstorm.pw 443 udp
 explicit-exit-notify 3
 mssfix 1400
 nobind
-compress
+compress lzo
 down-pre
 reneg-sec 0
 hand-window 17

--- a/mac/cstorm_Moldova.ovpn
+++ b/mac/cstorm_Moldova.ovpn
@@ -12,19 +12,18 @@ remote linux-moldova.cstorm.pw 443 udp
 explicit-exit-notify 3
 mssfix 1400
 nobind
-comp-lzo
+compress
 down-pre
 reneg-sec 0
 hand-window 17
 verb 4
 mute 3
 auth-user-pass
-ns-cert-type server
+remote-cert-tls server
 auth SHA512
 cipher AES-256-CBC
 tls-cipher TLS-DHE-RSA-WITH-AES-256-CBC-SHA
 tls-client
-key-method 2
 <ca>
 -----BEGIN CERTIFICATE-----
 MIIFIDCCBAigAwIBAgIJAKekpGXxXvhbMA0GCSqGSIb3DQEBCwUAMIG6MQswCQYD

--- a/mac/cstorm_Netherlands.ovpn
+++ b/mac/cstorm_Netherlands.ovpn
@@ -12,7 +12,7 @@ remote linux-netherlands.cstorm.pw 443 udp
 explicit-exit-notify 3
 mssfix 1400
 nobind
-compress
+compress lzo
 down-pre
 reneg-sec 0
 hand-window 17

--- a/mac/cstorm_Netherlands.ovpn
+++ b/mac/cstorm_Netherlands.ovpn
@@ -12,19 +12,18 @@ remote linux-netherlands.cstorm.pw 443 udp
 explicit-exit-notify 3
 mssfix 1400
 nobind
-comp-lzo
+compress
 down-pre
 reneg-sec 0
 hand-window 17
 verb 4
 mute 3
 auth-user-pass
-ns-cert-type server
+remote-cert-tls server
 auth SHA512
 cipher AES-256-CBC
 tls-cipher TLS-DHE-RSA-WITH-AES-256-CBC-SHA
 tls-client
-key-method 2
 <ca>
 -----BEGIN CERTIFICATE-----
 MIIFIDCCBAigAwIBAgIJAKekpGXxXvhbMA0GCSqGSIb3DQEBCwUAMIG6MQswCQYD

--- a/mac/cstorm_Paris.ovpn
+++ b/mac/cstorm_Paris.ovpn
@@ -12,7 +12,7 @@ remote linux-paris.cstorm.pw 443 udp
 explicit-exit-notify 3
 mssfix 1400
 nobind
-compress
+compress lzo
 down-pre
 reneg-sec 0
 hand-window 17

--- a/mac/cstorm_Paris.ovpn
+++ b/mac/cstorm_Paris.ovpn
@@ -12,19 +12,18 @@ remote linux-paris.cstorm.pw 443 udp
 explicit-exit-notify 3
 mssfix 1400
 nobind
-comp-lzo
+compress
 down-pre
 reneg-sec 0
 hand-window 17
 verb 4
 mute 3
 auth-user-pass
-ns-cert-type server
+remote-cert-tls server
 auth SHA512
 cipher AES-256-CBC
 tls-cipher TLS-DHE-RSA-WITH-AES-256-CBC-SHA
 tls-client
-key-method 2
 <ca>
 -----BEGIN CERTIFICATE-----
 MIIFIDCCBAigAwIBAgIJAKekpGXxXvhbMA0GCSqGSIb3DQEBCwUAMIG6MQswCQYD

--- a/mac/cstorm_Poland.ovpn
+++ b/mac/cstorm_Poland.ovpn
@@ -12,19 +12,18 @@ remote linux-poland.cstorm.pw 443 udp
 explicit-exit-notify 3
 mssfix 1400
 nobind
-comp-lzo
+compress
 down-pre
 reneg-sec 0
 hand-window 17
 verb 4
 mute 3
 auth-user-pass
-ns-cert-type server
+remote-cert-tls server
 auth SHA512
 cipher AES-256-CBC
 tls-cipher TLS-DHE-RSA-WITH-AES-256-CBC-SHA
 tls-client
-key-method 2
 <ca>
 -----BEGIN CERTIFICATE-----
 MIIFIDCCBAigAwIBAgIJAKekpGXxXvhbMA0GCSqGSIb3DQEBCwUAMIG6MQswCQYD

--- a/mac/cstorm_Poland.ovpn
+++ b/mac/cstorm_Poland.ovpn
@@ -12,7 +12,7 @@ remote linux-poland.cstorm.pw 443 udp
 explicit-exit-notify 3
 mssfix 1400
 nobind
-compress
+compress lzo
 down-pre
 reneg-sec 0
 hand-window 17

--- a/mac/cstorm_Rome.ovpn
+++ b/mac/cstorm_Rome.ovpn
@@ -12,19 +12,18 @@ remote linux-rome.cstorm.pw 443 udp
 explicit-exit-notify 3
 mssfix 1400
 nobind
-comp-lzo
+compress
 down-pre
 reneg-sec 0
 hand-window 17
 verb 4
 mute 3
 auth-user-pass
-ns-cert-type server
+remote-cert-tls server
 auth SHA512
 cipher AES-256-CBC
 tls-cipher TLS-DHE-RSA-WITH-AES-256-CBC-SHA
 tls-client
-key-method 2
 <ca>
 -----BEGIN CERTIFICATE-----
 MIIFIDCCBAigAwIBAgIJAKekpGXxXvhbMA0GCSqGSIb3DQEBCwUAMIG6MQswCQYD

--- a/mac/cstorm_Rome.ovpn
+++ b/mac/cstorm_Rome.ovpn
@@ -12,7 +12,7 @@ remote linux-rome.cstorm.pw 443 udp
 explicit-exit-notify 3
 mssfix 1400
 nobind
-compress
+compress lzo
 down-pre
 reneg-sec 0
 hand-window 17

--- a/mac/cstorm_Spain.ovpn
+++ b/mac/cstorm_Spain.ovpn
@@ -12,7 +12,7 @@ remote linux-spain.cstorm.pw 443 udp
 explicit-exit-notify 3
 mssfix 1400
 nobind
-compress
+compress lzo
 down-pre
 reneg-sec 0
 hand-window 17

--- a/mac/cstorm_Spain.ovpn
+++ b/mac/cstorm_Spain.ovpn
@@ -12,19 +12,18 @@ remote linux-spain.cstorm.pw 443 udp
 explicit-exit-notify 3
 mssfix 1400
 nobind
-comp-lzo
+compress
 down-pre
 reneg-sec 0
 hand-window 17
 verb 4
 mute 3
 auth-user-pass
-ns-cert-type server
+remote-cert-tls server
 auth SHA512
 cipher AES-256-CBC
 tls-cipher TLS-DHE-RSA-WITH-AES-256-CBC-SHA
 tls-client
-key-method 2
 <ca>
 -----BEGIN CERTIFICATE-----
 MIIFIDCCBAigAwIBAgIJAKekpGXxXvhbMA0GCSqGSIb3DQEBCwUAMIG6MQswCQYD

--- a/mac/cstorm_Switzerland.ovpn
+++ b/mac/cstorm_Switzerland.ovpn
@@ -12,7 +12,7 @@ remote linux-switzerland.cstorm.pw 443 udp
 explicit-exit-notify 3
 mssfix 1400
 nobind
-compress
+compress lzo
 down-pre
 reneg-sec 0
 hand-window 17

--- a/mac/cstorm_Switzerland.ovpn
+++ b/mac/cstorm_Switzerland.ovpn
@@ -12,19 +12,18 @@ remote linux-switzerland.cstorm.pw 443 udp
 explicit-exit-notify 3
 mssfix 1400
 nobind
-comp-lzo
+compress
 down-pre
 reneg-sec 0
 hand-window 17
 verb 4
 mute 3
 auth-user-pass
-ns-cert-type server
+remote-cert-tls server
 auth SHA512
 cipher AES-256-CBC
 tls-cipher TLS-DHE-RSA-WITH-AES-256-CBC-SHA
 tls-client
-key-method 2
 <ca>
 -----BEGIN CERTIFICATE-----
 MIIFIDCCBAigAwIBAgIJAKekpGXxXvhbMA0GCSqGSIb3DQEBCwUAMIG6MQswCQYD

--- a/mac/cstorm_USeast.ovpn
+++ b/mac/cstorm_USeast.ovpn
@@ -12,19 +12,18 @@ remote linux-useast.cstorm.pw 443 udp
 explicit-exit-notify 3
 mssfix 1400
 nobind
-comp-lzo
+compress
 down-pre
 reneg-sec 0
 hand-window 17
 verb 4
 mute 3
 auth-user-pass
-ns-cert-type server
+remote-cert-tls server
 auth SHA512
 cipher AES-256-CBC
 tls-cipher TLS-DHE-RSA-WITH-AES-256-CBC-SHA
 tls-client
-key-method 2
 <ca>
 -----BEGIN CERTIFICATE-----
 MIIFIDCCBAigAwIBAgIJAKekpGXxXvhbMA0GCSqGSIb3DQEBCwUAMIG6MQswCQYD

--- a/mac/cstorm_USeast.ovpn
+++ b/mac/cstorm_USeast.ovpn
@@ -12,7 +12,7 @@ remote linux-useast.cstorm.pw 443 udp
 explicit-exit-notify 3
 mssfix 1400
 nobind
-compress
+compress lzo
 down-pre
 reneg-sec 0
 hand-window 17

--- a/mac/cstorm_USnorth.ovpn
+++ b/mac/cstorm_USnorth.ovpn
@@ -12,19 +12,18 @@ remote linux-usnorth.cstorm.pw 443 udp
 explicit-exit-notify 3
 mssfix 1400
 nobind
-comp-lzo
+compress
 down-pre
 reneg-sec 0
 hand-window 17
 verb 4
 mute 3
 auth-user-pass
-ns-cert-type server
+remote-cert-tls server
 auth SHA512
 cipher AES-256-CBC
 tls-cipher TLS-DHE-RSA-WITH-AES-256-CBC-SHA
 tls-client
-key-method 2
 <ca>
 -----BEGIN CERTIFICATE-----
 MIIFIDCCBAigAwIBAgIJAKekpGXxXvhbMA0GCSqGSIb3DQEBCwUAMIG6MQswCQYD

--- a/mac/cstorm_USnorth.ovpn
+++ b/mac/cstorm_USnorth.ovpn
@@ -12,7 +12,7 @@ remote linux-usnorth.cstorm.pw 443 udp
 explicit-exit-notify 3
 mssfix 1400
 nobind
-compress
+compress lzo
 down-pre
 reneg-sec 0
 hand-window 17

--- a/mac/cstorm_USsouth.ovpn
+++ b/mac/cstorm_USsouth.ovpn
@@ -12,19 +12,18 @@ remote linux-ussouth.cstorm.pw 443 udp
 explicit-exit-notify 3
 mssfix 1400
 nobind
-comp-lzo
+compress
 down-pre
 reneg-sec 0
 hand-window 17
 verb 4
 mute 3
 auth-user-pass
-ns-cert-type server
+remote-cert-tls server
 auth SHA512
 cipher AES-256-CBC
 tls-cipher TLS-DHE-RSA-WITH-AES-256-CBC-SHA
 tls-client
-key-method 2
 <ca>
 -----BEGIN CERTIFICATE-----
 MIIFIDCCBAigAwIBAgIJAKekpGXxXvhbMA0GCSqGSIb3DQEBCwUAMIG6MQswCQYD

--- a/mac/cstorm_USsouth.ovpn
+++ b/mac/cstorm_USsouth.ovpn
@@ -12,7 +12,7 @@ remote linux-ussouth.cstorm.pw 443 udp
 explicit-exit-notify 3
 mssfix 1400
 nobind
-compress
+compress lzo
 down-pre
 reneg-sec 0
 hand-window 17

--- a/mac/cstorm_USwest.ovpn
+++ b/mac/cstorm_USwest.ovpn
@@ -12,7 +12,7 @@ remote linux-uswest.cstorm.pw 443 udp
 explicit-exit-notify 3
 mssfix 1400
 nobind
-compress
+compress lzo
 down-pre
 reneg-sec 0
 hand-window 17

--- a/mac/cstorm_USwest.ovpn
+++ b/mac/cstorm_USwest.ovpn
@@ -12,19 +12,18 @@ remote linux-uswest.cstorm.pw 443 udp
 explicit-exit-notify 3
 mssfix 1400
 nobind
-comp-lzo
+compress
 down-pre
 reneg-sec 0
 hand-window 17
 verb 4
 mute 3
 auth-user-pass
-ns-cert-type server
+remote-cert-tls server
 auth SHA512
 cipher AES-256-CBC
 tls-cipher TLS-DHE-RSA-WITH-AES-256-CBC-SHA
 tls-client
-key-method 2
 <ca>
 -----BEGIN CERTIFICATE-----
 MIIFIDCCBAigAwIBAgIJAKekpGXxXvhbMA0GCSqGSIb3DQEBCwUAMIG6MQswCQYD

--- a/mac/cstorm_Voodoo_romania_to_isleofman.ovpn
+++ b/mac/cstorm_Voodoo_romania_to_isleofman.ovpn
@@ -12,7 +12,7 @@ remote voodoo-linux-isleofman.cryptostorm.nu 443 udp
 explicit-exit-notify 3
 mssfix 1400
 nobind
-compress
+compress lzo
 down-pre
 reneg-sec 0
 hand-window 17

--- a/mac/cstorm_Voodoo_romania_to_isleofman.ovpn
+++ b/mac/cstorm_Voodoo_romania_to_isleofman.ovpn
@@ -12,19 +12,18 @@ remote voodoo-linux-isleofman.cryptostorm.nu 443 udp
 explicit-exit-notify 3
 mssfix 1400
 nobind
-comp-lzo
+compress
 down-pre
 reneg-sec 0
 hand-window 17
 verb 4
 mute 3
 auth-user-pass
-ns-cert-type server
+remote-cert-tls server
 auth SHA512
 cipher AES-256-CBC
 tls-cipher TLS-DHE-RSA-WITH-AES-256-CBC-SHA
 tls-client
-key-method 2
 <ca>
 -----BEGIN CERTIFICATE-----
 MIIFIDCCBAigAwIBAgIJAKekpGXxXvhbMA0GCSqGSIb3DQEBCwUAMIG6MQswCQYD

--- a/mac/cstorm_Voodoo_romania_to_russia.ovpn
+++ b/mac/cstorm_Voodoo_romania_to_russia.ovpn
@@ -12,19 +12,18 @@ remote voodoo-linux-russiawest.cryptostorm.nu 443 udp
 explicit-exit-notify 3
 mssfix 1400
 nobind
-comp-lzo
+compress
 down-pre
 reneg-sec 0
 hand-window 17
 verb 4
 mute 3
 auth-user-pass
-ns-cert-type server
+remote-cert-tls server
 auth SHA512
 cipher AES-256-CBC
 tls-cipher TLS-DHE-RSA-WITH-AES-256-CBC-SHA
 tls-client
-key-method 2
 # specification & location of server-verification PKI materials
 # for details, see https://cryptostorm.org/pki
 <ca>

--- a/mac/cstorm_Voodoo_romania_to_russia.ovpn
+++ b/mac/cstorm_Voodoo_romania_to_russia.ovpn
@@ -12,7 +12,7 @@ remote voodoo-linux-russiawest.cryptostorm.nu 443 udp
 explicit-exit-notify 3
 mssfix 1400
 nobind
-compress
+compress lzo
 down-pre
 reneg-sec 0
 hand-window 17

--- a/voodoo/cstorm-voodoo_linux-romania_to_isleofman.ovpn
+++ b/voodoo/cstorm-voodoo_linux-romania_to_isleofman.ovpn
@@ -11,7 +11,7 @@ remote voodoo-linux-isleofman.cryptostorm.nu 443 udp
 explicit-exit-notify 3
 mssfix 1400
 nobind
-compress
+compress lzo
 down-pre
 reneg-sec 0
 hand-window 17

--- a/voodoo/cstorm-voodoo_linux-romania_to_isleofman.ovpn
+++ b/voodoo/cstorm-voodoo_linux-romania_to_isleofman.ovpn
@@ -11,19 +11,18 @@ remote voodoo-linux-isleofman.cryptostorm.nu 443 udp
 explicit-exit-notify 3
 mssfix 1400
 nobind
-comp-lzo
+compress
 down-pre
 reneg-sec 0
 hand-window 17
 verb 4
 mute 3
 auth-user-pass
-ns-cert-type server
+remote-cert-tls server
 auth SHA512
 cipher AES-256-CBC
 tls-cipher TLS-DHE-RSA-WITH-AES-256-CBC-SHA
 tls-client
-key-method 2
 ca ca.crt
 # specification & location of server-verification PKI materials
 # for details, see https://cryptostorm.org/pki

--- a/voodoo/cstorm-voodoo_linux-romania_to_russia.ovpn
+++ b/voodoo/cstorm-voodoo_linux-romania_to_russia.ovpn
@@ -11,19 +11,18 @@ remote voodoo-linux-russia.cryptostorm.nu 443 udp
 explicit-exit-notify 3
 mssfix 1400
 nobind
-comp-lzo
+compress
 down-pre
 reneg-sec 0
 hand-window 17
 verb 4
 mute 3
 auth-user-pass
-ns-cert-type server
+remote-cert-tls server
 auth SHA512
 cipher AES-256-CBC
 tls-cipher TLS-DHE-RSA-WITH-AES-256-CBC-SHA
 tls-client
-key-method 2
 ca ca.crt
 # specification & location of server-verification PKI materials
 # for details, see https://cryptostorm.org/pki

--- a/voodoo/cstorm-voodoo_linux-romania_to_russia.ovpn
+++ b/voodoo/cstorm-voodoo_linux-romania_to_russia.ovpn
@@ -11,7 +11,7 @@ remote voodoo-linux-russia.cryptostorm.nu 443 udp
 explicit-exit-notify 3
 mssfix 1400
 nobind
-compress
+compress lzo
 down-pre
 reneg-sec 0
 hand-window 17

--- a/voodoo/cstorm-voodoo_windows-denmark_to_isleofman.ovpn
+++ b/voodoo/cstorm-voodoo_windows-denmark_to_isleofman.ovpn
@@ -11,7 +11,7 @@ remote voodoo-windows-isleofman.cstorm.pw 443 udp
 explicit-exit-notify 3
 fragment 1400
 nobind
-compress
+compress lzo
 down-pre
 reneg-sec 0
 hand-window 17

--- a/voodoo/cstorm-voodoo_windows-denmark_to_isleofman.ovpn
+++ b/voodoo/cstorm-voodoo_windows-denmark_to_isleofman.ovpn
@@ -11,19 +11,18 @@ remote voodoo-windows-isleofman.cstorm.pw 443 udp
 explicit-exit-notify 3
 fragment 1400
 nobind
-comp-lzo
+compress
 down-pre
 reneg-sec 0
 hand-window 17
 verb 4
 mute 3
 auth-user-pass
-ns-cert-type server
+remote-cert-tls server
 auth SHA512
 cipher AES-256-CBC
 tls-cipher TLS-DHE-RSA-WITH-AES-256-CBC-SHA
 tls-client
-key-method 2
 ca ca.crt
 # specification & location of server-verification PKI materials
 # for details, see https://cryptostorm.org/pki

--- a/voodoo/cstorm-voodoo_windows-italy_to_romania.ovpn
+++ b/voodoo/cstorm-voodoo_windows-italy_to_romania.ovpn
@@ -11,19 +11,18 @@ remote voodoo-windows-romania.cstorm.pw 443 udp
 explicit-exit-notify 3
 fragment 1400
 nobind
-comp-lzo
+compress
 down-pre
 reneg-sec 0
 hand-window 17
 verb 4
 mute 3
 auth-user-pass
-ns-cert-type server
+remote-cert-tls server
 auth SHA512
 cipher AES-256-CBC
 tls-cipher TLS-DHE-RSA-WITH-AES-256-CBC-SHA
 tls-client
-key-method 2
 ca ca.crt
 # specification & location of server-verification PKI materials
 # for details, see https://cryptostorm.org/pki

--- a/voodoo/cstorm-voodoo_windows-italy_to_romania.ovpn
+++ b/voodoo/cstorm-voodoo_windows-italy_to_romania.ovpn
@@ -11,7 +11,7 @@ remote voodoo-windows-romania.cstorm.pw 443 udp
 explicit-exit-notify 3
 fragment 1400
 nobind
-compress
+compress lzo
 down-pre
 reneg-sec 0
 hand-window 17

--- a/voodoo/cstorm-voodoo_windows-romania_to_russia.ovpn
+++ b/voodoo/cstorm-voodoo_windows-romania_to_russia.ovpn
@@ -11,19 +11,18 @@ remote voodoo-windows-russia.cstorm.pw 443 udp
 explicit-exit-notify 3
 fragment 1400
 nobind
-comp-lzo
+compress
 down-pre
 reneg-sec 0
 hand-window 17
 verb 4
 mute 3
 auth-user-pass
-ns-cert-type server
+remote-cert-tls server
 auth SHA512
 cipher AES-256-CBC
 tls-cipher TLS-DHE-RSA-WITH-AES-256-CBC-SHA
 tls-client
-key-method 2
 ca ca.crt
 # specification & location of server-verification PKI materials
 # for details, see https://cryptostorm.org/pki

--- a/voodoo/cstorm-voodoo_windows-romania_to_russia.ovpn
+++ b/voodoo/cstorm-voodoo_windows-romania_to_russia.ovpn
@@ -11,7 +11,7 @@ remote voodoo-windows-russia.cstorm.pw 443 udp
 explicit-exit-notify 3
 fragment 1400
 nobind
-compress
+compress lzo
 down-pre
 reneg-sec 0
 hand-window 17

--- a/windows/cstorm_windows-balancer_tcp.ovpn
+++ b/windows/cstorm_windows-balancer_tcp.ovpn
@@ -9,19 +9,18 @@ remote windows-balancer.cryptostorm.nu 443 tcp
 remote windows-balancer.cryptostorm.org 443 tcp
 remote windows-balancer.cstorm.pw 443 tcp
 nobind
-comp-lzo
+compress
 down-pre
 reneg-sec 0
 hand-window 17
 verb 4
 mute 3
 auth-user-pass
-ns-cert-type server
+remote-cert-tls server
 auth SHA512
 cipher AES-256-CBC
 tls-cipher TLS-DHE-RSA-WITH-AES-256-CBC-SHA
 tls-client
-key-method 2
 ca ca.crt
 # specification & location of server-verification PKI materials
 # for details, see https://cryptostorm.org/pki

--- a/windows/cstorm_windows-balancer_tcp.ovpn
+++ b/windows/cstorm_windows-balancer_tcp.ovpn
@@ -9,7 +9,7 @@ remote windows-balancer.cryptostorm.nu 443 tcp
 remote windows-balancer.cryptostorm.org 443 tcp
 remote windows-balancer.cstorm.pw 443 tcp
 nobind
-compress
+compress lzo
 down-pre
 reneg-sec 0
 hand-window 17

--- a/windows/cstorm_windows-balancer_udp.ovpn
+++ b/windows/cstorm_windows-balancer_udp.ovpn
@@ -11,19 +11,18 @@ remote windows-balancer.cstorm.pw 443 udp
 explicit-exit-notify 3
 fragment 1400
 nobind
-comp-lzo
+compress
 down-pre
 reneg-sec 0
 hand-window 17
 verb 4
 mute 3
 auth-user-pass
-ns-cert-type server
+remote-cert-tls server
 auth SHA512
 cipher AES-256-CBC
 tls-cipher TLS-DHE-RSA-WITH-AES-256-CBC-SHA
 tls-client
-key-method 2
 ca ca.crt
 # specification & location of server-verification PKI materials
 # for details, see https://cryptostorm.org/pki

--- a/windows/cstorm_windows-balancer_udp.ovpn
+++ b/windows/cstorm_windows-balancer_udp.ovpn
@@ -11,7 +11,7 @@ remote windows-balancer.cstorm.pw 443 udp
 explicit-exit-notify 3
 fragment 1400
 nobind
-compress
+compress lzo
 down-pre
 reneg-sec 0
 hand-window 17

--- a/windows/cstorm_windows-canadaeast_tcp.ovpn
+++ b/windows/cstorm_windows-canadaeast_tcp.ovpn
@@ -9,19 +9,18 @@ remote windows-canadaeast.cryptostorm.nu 443 tcp
 remote windows-canadaeast.cryptostorm.org 443 tcp
 remote windows-canadaeast.cstorm.pw 443 tcp
 nobind
-comp-lzo
+compress
 down-pre
 reneg-sec 0
 hand-window 17
 verb 4
 mute 3
 auth-user-pass
-ns-cert-type server
+remote-cert-tls server
 auth SHA512
 cipher AES-256-CBC
 tls-cipher TLS-DHE-RSA-WITH-AES-256-CBC-SHA
 tls-client
-key-method 2
 ca ca.crt
 # specification & location of server-verification PKI materials
 # for details, see https://cryptostorm.org/pki

--- a/windows/cstorm_windows-canadaeast_tcp.ovpn
+++ b/windows/cstorm_windows-canadaeast_tcp.ovpn
@@ -9,7 +9,7 @@ remote windows-canadaeast.cryptostorm.nu 443 tcp
 remote windows-canadaeast.cryptostorm.org 443 tcp
 remote windows-canadaeast.cstorm.pw 443 tcp
 nobind
-compress
+compress lzo
 down-pre
 reneg-sec 0
 hand-window 17

--- a/windows/cstorm_windows-canadaeast_udp.ovpn
+++ b/windows/cstorm_windows-canadaeast_udp.ovpn
@@ -11,19 +11,18 @@ remote windows-canadaeast.cstorm.pw 443 udp
 explicit-exit-notify 3
 fragment 1400
 nobind
-comp-lzo
+compress
 down-pre
 reneg-sec 0
 hand-window 17
 verb 4
 mute 3
 auth-user-pass
-ns-cert-type server
+remote-cert-tls server
 auth SHA512
 cipher AES-256-CBC
 tls-cipher TLS-DHE-RSA-WITH-AES-256-CBC-SHA
 tls-client
-key-method 2
 ca ca.crt
 # specification & location of server-verification PKI materials
 # for details, see https://cryptostorm.org/pki

--- a/windows/cstorm_windows-canadaeast_udp.ovpn
+++ b/windows/cstorm_windows-canadaeast_udp.ovpn
@@ -11,7 +11,7 @@ remote windows-canadaeast.cstorm.pw 443 udp
 explicit-exit-notify 3
 fragment 1400
 nobind
-compress
+compress lzo
 down-pre
 reneg-sec 0
 hand-window 17

--- a/windows/cstorm_windows-canadawest_tcp.ovpn
+++ b/windows/cstorm_windows-canadawest_tcp.ovpn
@@ -9,7 +9,7 @@ remote windows-canadawest.cryptostorm.nu 443 tcp
 remote windows-canadawest.cryptostorm.org 443 tcp
 remote windows-canadawest.cstorm.pw 443 tcp
 nobind
-compress
+compress lzo
 down-pre
 reneg-sec 0
 hand-window 17

--- a/windows/cstorm_windows-canadawest_tcp.ovpn
+++ b/windows/cstorm_windows-canadawest_tcp.ovpn
@@ -9,19 +9,18 @@ remote windows-canadawest.cryptostorm.nu 443 tcp
 remote windows-canadawest.cryptostorm.org 443 tcp
 remote windows-canadawest.cstorm.pw 443 tcp
 nobind
-comp-lzo
+compress
 down-pre
 reneg-sec 0
 hand-window 17
 verb 4
 mute 3
 auth-user-pass
-ns-cert-type server
+remote-cert-tls server
 auth SHA512
 cipher AES-256-CBC
 tls-cipher TLS-DHE-RSA-WITH-AES-256-CBC-SHA
 tls-client
-key-method 2
 ca ca.crt
 # specification & location of server-verification PKI materials
 # for details, see https://cryptostorm.org/pki

--- a/windows/cstorm_windows-canadawest_udp.ovpn
+++ b/windows/cstorm_windows-canadawest_udp.ovpn
@@ -11,19 +11,18 @@ remote windows-canadawest.cstorm.pw 443 udp
 explicit-exit-notify 3
 fragment 1400
 nobind
-comp-lzo
+compress
 down-pre
 reneg-sec 0
 hand-window 17
 verb 4
 mute 3
 auth-user-pass
-ns-cert-type server
+remote-cert-tls server
 auth SHA512
 cipher AES-256-CBC
 tls-cipher TLS-DHE-RSA-WITH-AES-256-CBC-SHA
 tls-client
-key-method 2
 ca ca.crt
 # specification & location of server-verification PKI materials
 # for details, see https://cryptostorm.org/pki

--- a/windows/cstorm_windows-canadawest_udp.ovpn
+++ b/windows/cstorm_windows-canadawest_udp.ovpn
@@ -11,7 +11,7 @@ remote windows-canadawest.cstorm.pw 443 udp
 explicit-exit-notify 3
 fragment 1400
 nobind
-compress
+compress lzo
 down-pre
 reneg-sec 0
 hand-window 17

--- a/windows/cstorm_windows-denmark_tcp.ovpn
+++ b/windows/cstorm_windows-denmark_tcp.ovpn
@@ -9,7 +9,7 @@ remote windows-denmark.cryptostorm.nu 443 tcp
 remote windows-denmark.cryptostorm.org 443 tcp
 remote windows-denmark.cstorm.pw 443 tcp
 nobind
-compress
+compress lzo
 down-pre
 reneg-sec 0
 hand-window 17

--- a/windows/cstorm_windows-denmark_tcp.ovpn
+++ b/windows/cstorm_windows-denmark_tcp.ovpn
@@ -9,19 +9,18 @@ remote windows-denmark.cryptostorm.nu 443 tcp
 remote windows-denmark.cryptostorm.org 443 tcp
 remote windows-denmark.cstorm.pw 443 tcp
 nobind
-comp-lzo
+compress
 down-pre
 reneg-sec 0
 hand-window 17
 verb 4
 mute 3
 auth-user-pass
-ns-cert-type server
+remote-cert-tls server
 auth SHA512
 cipher AES-256-CBC
 tls-cipher TLS-DHE-RSA-WITH-AES-256-CBC-SHA
 tls-client
-key-method 2
 ca ca.crt
 # specification & location of server-verification PKI materials
 # for details, see https://cryptostorm.org/pki

--- a/windows/cstorm_windows-denmark_udp.ovpn
+++ b/windows/cstorm_windows-denmark_udp.ovpn
@@ -11,19 +11,18 @@ remote windows-denmark.cstorm.pw 443 udp
 explicit-exit-notify 3
 fragment 1400
 nobind
-comp-lzo
+compress
 down-pre
 reneg-sec 0
 hand-window 17
 verb 4
 mute 3
 auth-user-pass
-ns-cert-type server
+remote-cert-tls server
 auth SHA512
 cipher AES-256-CBC
 tls-cipher TLS-DHE-RSA-WITH-AES-256-CBC-SHA
 tls-client
-key-method 2
 ca ca.crt
 # specification & location of server-verification PKI materials
 # for details, see https://cryptostorm.org/pki

--- a/windows/cstorm_windows-denmark_udp.ovpn
+++ b/windows/cstorm_windows-denmark_udp.ovpn
@@ -11,7 +11,7 @@ remote windows-denmark.cstorm.pw 443 udp
 explicit-exit-notify 3
 fragment 1400
 nobind
-compress
+compress lzo
 down-pre
 reneg-sec 0
 hand-window 17

--- a/windows/cstorm_windows-dusseldorf_tcp.ovpn
+++ b/windows/cstorm_windows-dusseldorf_tcp.ovpn
@@ -9,7 +9,7 @@ remote windows-dusseldorf.cryptostorm.nu 443 tcp
 remote windows-dusseldorf.cryptostorm.org 443 tcp
 remote windows-dusseldorf.cstorm.pw 443 tcp
 nobind
-compress
+compress lzo
 down-pre
 reneg-sec 0
 hand-window 17

--- a/windows/cstorm_windows-dusseldorf_tcp.ovpn
+++ b/windows/cstorm_windows-dusseldorf_tcp.ovpn
@@ -9,19 +9,18 @@ remote windows-dusseldorf.cryptostorm.nu 443 tcp
 remote windows-dusseldorf.cryptostorm.org 443 tcp
 remote windows-dusseldorf.cstorm.pw 443 tcp
 nobind
-comp-lzo
+compress
 down-pre
 reneg-sec 0
 hand-window 17
 verb 4
 mute 3
 auth-user-pass
-ns-cert-type server
+remote-cert-tls server
 auth SHA512
 cipher AES-256-CBC
 tls-cipher TLS-DHE-RSA-WITH-AES-256-CBC-SHA
 tls-client
-key-method 2
 ca ca.crt
 # specification & location of server-verification PKI materials
 # for details, see https://cryptostorm.org/pki

--- a/windows/cstorm_windows-dusseldorf_udp.ovpn
+++ b/windows/cstorm_windows-dusseldorf_udp.ovpn
@@ -11,7 +11,7 @@ remote windows-dusseldorf.cstorm.pw 443 udp
 explicit-exit-notify 3
 fragment 1400
 nobind
-compress
+compress lzo
 down-pre
 reneg-sec 0
 hand-window 17

--- a/windows/cstorm_windows-dusseldorf_udp.ovpn
+++ b/windows/cstorm_windows-dusseldorf_udp.ovpn
@@ -11,19 +11,18 @@ remote windows-dusseldorf.cstorm.pw 443 udp
 explicit-exit-notify 3
 fragment 1400
 nobind
-comp-lzo
+compress
 down-pre
 reneg-sec 0
 hand-window 17
 verb 4
 mute 3
 auth-user-pass
-ns-cert-type server
+remote-cert-tls server
 auth SHA512
 cipher AES-256-CBC
 tls-cipher TLS-DHE-RSA-WITH-AES-256-CBC-SHA
 tls-client
-key-method 2
 ca ca.crt
 # specification & location of server-verification PKI materials
 # for details, see https://cryptostorm.org/pki

--- a/windows/cstorm_windows-england_tcp.ovpn
+++ b/windows/cstorm_windows-england_tcp.ovpn
@@ -9,7 +9,7 @@ remote windows-england.cryptostorm.nu 443 tcp
 remote windows-england.cryptostorm.org 443 tcp
 remote windows-england.cstorm.pw 443 tcp
 nobind
-compress
+compress lzo
 down-pre
 reneg-sec 0
 hand-window 17

--- a/windows/cstorm_windows-england_tcp.ovpn
+++ b/windows/cstorm_windows-england_tcp.ovpn
@@ -9,19 +9,18 @@ remote windows-england.cryptostorm.nu 443 tcp
 remote windows-england.cryptostorm.org 443 tcp
 remote windows-england.cstorm.pw 443 tcp
 nobind
-comp-lzo
+compress
 down-pre
 reneg-sec 0
 hand-window 17
 verb 4
 mute 3
 auth-user-pass
-ns-cert-type server
+remote-cert-tls server
 auth SHA512
 cipher AES-256-CBC
 tls-cipher TLS-DHE-RSA-WITH-AES-256-CBC-SHA
 tls-client
-key-method 2
 ca ca.crt
 # specification & location of server-verification PKI materials
 # for details, see https://cryptostorm.org/pki

--- a/windows/cstorm_windows-england_udp.ovpn
+++ b/windows/cstorm_windows-england_udp.ovpn
@@ -11,19 +11,18 @@ remote windows-england.cstorm.pw 443 udp
 explicit-exit-notify 3
 fragment 1400
 nobind
-comp-lzo
+compress
 down-pre
 reneg-sec 0
 hand-window 17
 verb 4
 mute 3
 auth-user-pass
-ns-cert-type server
+remote-cert-tls server
 auth SHA512
 cipher AES-256-CBC
 tls-cipher TLS-DHE-RSA-WITH-AES-256-CBC-SHA
 tls-client
-key-method 2
 ca ca.crt
 # specification & location of server-verification PKI materials
 # for details, see https://cryptostorm.org/pki

--- a/windows/cstorm_windows-england_udp.ovpn
+++ b/windows/cstorm_windows-england_udp.ovpn
@@ -11,7 +11,7 @@ remote windows-england.cstorm.pw 443 udp
 explicit-exit-notify 3
 fragment 1400
 nobind
-compress
+compress lzo
 down-pre
 reneg-sec 0
 hand-window 17

--- a/windows/cstorm_windows-finland_tcp.ovpn
+++ b/windows/cstorm_windows-finland_tcp.ovpn
@@ -9,19 +9,18 @@ remote windows-finland.cryptostorm.nu 443 tcp
 remote windows-finland.cryptostorm.org 443 tcp
 remote windows-finland.cstorm.pw 443 tcp
 nobind
-comp-lzo
+compress
 down-pre
 reneg-sec 0
 hand-window 17
 verb 4
 mute 3
 auth-user-pass
-ns-cert-type server
+remote-cert-tls server
 auth SHA512
 cipher AES-256-CBC
 tls-cipher TLS-DHE-RSA-WITH-AES-256-CBC-SHA
 tls-client
-key-method 2
 ca ca.crt
 # specification & location of server-verification PKI materials
 # for details, see https://cryptostorm.org/pki

--- a/windows/cstorm_windows-finland_tcp.ovpn
+++ b/windows/cstorm_windows-finland_tcp.ovpn
@@ -9,7 +9,7 @@ remote windows-finland.cryptostorm.nu 443 tcp
 remote windows-finland.cryptostorm.org 443 tcp
 remote windows-finland.cstorm.pw 443 tcp
 nobind
-compress
+compress lzo
 down-pre
 reneg-sec 0
 hand-window 17

--- a/windows/cstorm_windows-finland_udp.ovpn
+++ b/windows/cstorm_windows-finland_udp.ovpn
@@ -11,19 +11,18 @@ remote windows-finland.cstorm.pw 443 udp
 explicit-exit-notify 3
 fragment 1400
 nobind
-comp-lzo
+compress
 down-pre
 reneg-sec 0
 hand-window 17
 verb 4
 mute 3
 auth-user-pass
-ns-cert-type server
+remote-cert-tls server
 auth SHA512
 cipher AES-256-CBC
 tls-cipher TLS-DHE-RSA-WITH-AES-256-CBC-SHA
 tls-client
-key-method 2
 ca ca.crt
 # specification & location of server-verification PKI materials
 # for details, see https://cryptostorm.org/pki

--- a/windows/cstorm_windows-finland_udp.ovpn
+++ b/windows/cstorm_windows-finland_udp.ovpn
@@ -11,7 +11,7 @@ remote windows-finland.cstorm.pw 443 udp
 explicit-exit-notify 3
 fragment 1400
 nobind
-compress
+compress lzo
 down-pre
 reneg-sec 0
 hand-window 17

--- a/windows/cstorm_windows-frankfurt_tcp.ovpn
+++ b/windows/cstorm_windows-frankfurt_tcp.ovpn
@@ -9,19 +9,18 @@ remote windows-frankfurt.cryptostorm.nu 443 tcp
 remote windows-frankfurt.cryptostorm.org 443 tcp
 remote windows-frankfurt.cstorm.pw 443 tcp
 nobind
-comp-lzo
+compress
 down-pre
 reneg-sec 0
 hand-window 17
 verb 4
 mute 3
 auth-user-pass
-ns-cert-type server
+remote-cert-tls server
 auth SHA512
 cipher AES-256-CBC
 tls-cipher TLS-DHE-RSA-WITH-AES-256-CBC-SHA
 tls-client
-key-method 2
 ca ca.crt
 # specification & location of server-verification PKI materials
 # for details, see https://cryptostorm.org/pki

--- a/windows/cstorm_windows-frankfurt_tcp.ovpn
+++ b/windows/cstorm_windows-frankfurt_tcp.ovpn
@@ -9,7 +9,7 @@ remote windows-frankfurt.cryptostorm.nu 443 tcp
 remote windows-frankfurt.cryptostorm.org 443 tcp
 remote windows-frankfurt.cstorm.pw 443 tcp
 nobind
-compress
+compress lzo
 down-pre
 reneg-sec 0
 hand-window 17

--- a/windows/cstorm_windows-frankfurt_udp.ovpn
+++ b/windows/cstorm_windows-frankfurt_udp.ovpn
@@ -11,19 +11,18 @@ remote windows-frankfurt.cstorm.pw 443 udp
 explicit-exit-notify 3
 fragment 1400
 nobind
-comp-lzo
+compress
 down-pre
 reneg-sec 0
 hand-window 17
 verb 4
 mute 3
 auth-user-pass
-ns-cert-type server
+remote-cert-tls server
 auth SHA512
 cipher AES-256-CBC
 tls-cipher TLS-DHE-RSA-WITH-AES-256-CBC-SHA
 tls-client
-key-method 2
 ca ca.crt
 # specification & location of server-verification PKI materials
 # for details, see https://cryptostorm.org/pki

--- a/windows/cstorm_windows-frankfurt_udp.ovpn
+++ b/windows/cstorm_windows-frankfurt_udp.ovpn
@@ -11,7 +11,7 @@ remote windows-frankfurt.cstorm.pw 443 udp
 explicit-exit-notify 3
 fragment 1400
 nobind
-compress
+compress lzo
 down-pre
 reneg-sec 0
 hand-window 17

--- a/windows/cstorm_windows-latvia_tcp.ovpn
+++ b/windows/cstorm_windows-latvia_tcp.ovpn
@@ -9,19 +9,18 @@ remote windows-latvia.cryptostorm.nu 443 tcp
 remote windows-latvia.cryptostorm.org 443 tcp
 remote windows-latvia.cstorm.pw 443 tcp
 nobind
-comp-lzo
+compress
 down-pre
 reneg-sec 0
 hand-window 17
 verb 4
 mute 3
 auth-user-pass
-ns-cert-type server
+remote-cert-tls server
 auth SHA512
 cipher AES-256-CBC
 tls-cipher TLS-DHE-RSA-WITH-AES-256-CBC-SHA
 tls-client
-key-method 2
 ca ca.crt
 # specification & location of server-verification PKI materials
 # for details, see https://cryptostorm.org/pki

--- a/windows/cstorm_windows-latvia_tcp.ovpn
+++ b/windows/cstorm_windows-latvia_tcp.ovpn
@@ -9,7 +9,7 @@ remote windows-latvia.cryptostorm.nu 443 tcp
 remote windows-latvia.cryptostorm.org 443 tcp
 remote windows-latvia.cstorm.pw 443 tcp
 nobind
-compress
+compress lzo
 down-pre
 reneg-sec 0
 hand-window 17

--- a/windows/cstorm_windows-latvia_udp.ovpn
+++ b/windows/cstorm_windows-latvia_udp.ovpn
@@ -11,19 +11,18 @@ remote windows-latvia.cstorm.pw 443 udp
 explicit-exit-notify 3
 fragment 1400
 nobind
-comp-lzo
+compress
 down-pre
 reneg-sec 0
 hand-window 17
 verb 4
 mute 3
 auth-user-pass
-ns-cert-type server
+remote-cert-tls server
 auth SHA512
 cipher AES-256-CBC
 tls-cipher TLS-DHE-RSA-WITH-AES-256-CBC-SHA
 tls-client
-key-method 2
 ca ca.crt
 # specification & location of server-verification PKI materials
 # for details, see https://cryptostorm.org/pki

--- a/windows/cstorm_windows-latvia_udp.ovpn
+++ b/windows/cstorm_windows-latvia_udp.ovpn
@@ -11,7 +11,7 @@ remote windows-latvia.cstorm.pw 443 udp
 explicit-exit-notify 3
 fragment 1400
 nobind
-compress
+compress lzo
 down-pre
 reneg-sec 0
 hand-window 17

--- a/windows/cstorm_windows-lisbon_tcp.ovpn
+++ b/windows/cstorm_windows-lisbon_tcp.ovpn
@@ -9,7 +9,7 @@ remote windows-lisbon.cryptostorm.nu 443 tcp
 remote windows-lisbon.cryptostorm.org 443 tcp
 remote windows-lisbon.cstorm.pw 443 tcp
 nobind
-compress
+compress lzo
 down-pre
 reneg-sec 0
 hand-window 17

--- a/windows/cstorm_windows-lisbon_tcp.ovpn
+++ b/windows/cstorm_windows-lisbon_tcp.ovpn
@@ -9,19 +9,18 @@ remote windows-lisbon.cryptostorm.nu 443 tcp
 remote windows-lisbon.cryptostorm.org 443 tcp
 remote windows-lisbon.cstorm.pw 443 tcp
 nobind
-comp-lzo
+compress
 down-pre
 reneg-sec 0
 hand-window 17
 verb 4
 mute 3
 auth-user-pass
-ns-cert-type server
+remote-cert-tls server
 auth SHA512
 cipher AES-256-CBC
 tls-cipher TLS-DHE-RSA-WITH-AES-256-CBC-SHA
 tls-client
-key-method 2
 ca ca.crt
 # specification & location of server-verification PKI materials
 # for details, see https://cryptostorm.org/pki

--- a/windows/cstorm_windows-lisbon_udp.ovpn
+++ b/windows/cstorm_windows-lisbon_udp.ovpn
@@ -11,7 +11,7 @@ remote windows-lisbon.cstorm.pw 443 udp
 explicit-exit-notify 3
 fragment 1400
 nobind
-compress
+compress lzo
 down-pre
 reneg-sec 0
 hand-window 17

--- a/windows/cstorm_windows-lisbon_udp.ovpn
+++ b/windows/cstorm_windows-lisbon_udp.ovpn
@@ -11,19 +11,18 @@ remote windows-lisbon.cstorm.pw 443 udp
 explicit-exit-notify 3
 fragment 1400
 nobind
-comp-lzo
+compress
 down-pre
 reneg-sec 0
 hand-window 17
 verb 4
 mute 3
 auth-user-pass
-ns-cert-type server
+remote-cert-tls server
 auth SHA512
 cipher AES-256-CBC
 tls-cipher TLS-DHE-RSA-WITH-AES-256-CBC-SHA
 tls-client
-key-method 2
 ca ca.crt
 # specification & location of server-verification PKI materials
 # for details, see https://cryptostorm.org/pki

--- a/windows/cstorm_windows-lithuania_tcp.ovpn
+++ b/windows/cstorm_windows-lithuania_tcp.ovpn
@@ -9,7 +9,7 @@ remote windows-lithuania.cryptostorm.nu 443 tcp
 remote windows-lithuania.cryptostorm.org 443 tcp
 remote windows-lithuania.cstorm.pw 443 tcp
 nobind
-compress
+compress lzo
 down-pre
 reneg-sec 0
 hand-window 17

--- a/windows/cstorm_windows-lithuania_tcp.ovpn
+++ b/windows/cstorm_windows-lithuania_tcp.ovpn
@@ -9,19 +9,18 @@ remote windows-lithuania.cryptostorm.nu 443 tcp
 remote windows-lithuania.cryptostorm.org 443 tcp
 remote windows-lithuania.cstorm.pw 443 tcp
 nobind
-comp-lzo
+compress
 down-pre
 reneg-sec 0
 hand-window 17
 verb 4
 mute 3
 auth-user-pass
-ns-cert-type server
+remote-cert-tls server
 auth SHA512
 cipher AES-256-CBC
 tls-cipher TLS-DHE-RSA-WITH-AES-256-CBC-SHA
 tls-client
-key-method 2
 ca ca.crt
 # specification & location of server-verification PKI materials
 # for details, see https://cryptostorm.org/pki

--- a/windows/cstorm_windows-lithuania_udp.ovpn
+++ b/windows/cstorm_windows-lithuania_udp.ovpn
@@ -11,19 +11,18 @@ remote windows-lithuania.cstorm.pw 443 udp
 explicit-exit-notify 3
 fragment 1400
 nobind
-comp-lzo
+compress
 down-pre
 reneg-sec 0
 hand-window 17
 verb 4
 mute 3
 auth-user-pass
-ns-cert-type server
+remote-cert-tls server
 auth SHA512
 cipher AES-256-CBC
 tls-cipher TLS-DHE-RSA-WITH-AES-256-CBC-SHA
 tls-client
-key-method 2
 ca ca.crt
 # specification & location of server-verification PKI materials
 # for details, see https://cryptostorm.org/pki

--- a/windows/cstorm_windows-lithuania_udp.ovpn
+++ b/windows/cstorm_windows-lithuania_udp.ovpn
@@ -11,7 +11,7 @@ remote windows-lithuania.cstorm.pw 443 udp
 explicit-exit-notify 3
 fragment 1400
 nobind
-compress
+compress lzo
 down-pre
 reneg-sec 0
 hand-window 17

--- a/windows/cstorm_windows-moldova_tcp.ovpn
+++ b/windows/cstorm_windows-moldova_tcp.ovpn
@@ -9,7 +9,7 @@ remote windows-moldova.cryptostorm.nu 443 tcp
 remote windows-moldova.cryptostorm.org 443 tcp
 remote windows-moldova.cstorm.pw 443 tcp
 nobind
-compress
+compress lzo
 down-pre
 reneg-sec 0
 hand-window 17

--- a/windows/cstorm_windows-moldova_tcp.ovpn
+++ b/windows/cstorm_windows-moldova_tcp.ovpn
@@ -9,19 +9,18 @@ remote windows-moldova.cryptostorm.nu 443 tcp
 remote windows-moldova.cryptostorm.org 443 tcp
 remote windows-moldova.cstorm.pw 443 tcp
 nobind
-comp-lzo
+compress
 down-pre
 reneg-sec 0
 hand-window 17
 verb 4
 mute 3
 auth-user-pass
-ns-cert-type server
+remote-cert-tls server
 auth SHA512
 cipher AES-256-CBC
 tls-cipher TLS-DHE-RSA-WITH-AES-256-CBC-SHA
 tls-client
-key-method 2
 ca ca.crt
 # specification & location of server-verification PKI materials
 # for details, see https://cryptostorm.org/pki

--- a/windows/cstorm_windows-moldova_udp.ovpn
+++ b/windows/cstorm_windows-moldova_udp.ovpn
@@ -11,19 +11,18 @@ remote windows-moldova.cstorm.pw 443 udp
 explicit-exit-notify 3
 fragment 1400
 nobind
-comp-lzo
+compress
 down-pre
 reneg-sec 0
 hand-window 17
 verb 4
 mute 3
 auth-user-pass
-ns-cert-type server
+remote-cert-tls server
 auth SHA512
 cipher AES-256-CBC
 tls-cipher TLS-DHE-RSA-WITH-AES-256-CBC-SHA
 tls-client
-key-method 2
 ca ca.crt
 # specification & location of server-verification PKI materials
 # for details, see https://cryptostorm.org/pki

--- a/windows/cstorm_windows-moldova_udp.ovpn
+++ b/windows/cstorm_windows-moldova_udp.ovpn
@@ -11,7 +11,7 @@ remote windows-moldova.cstorm.pw 443 udp
 explicit-exit-notify 3
 fragment 1400
 nobind
-compress
+compress lzo
 down-pre
 reneg-sec 0
 hand-window 17

--- a/windows/cstorm_windows-netherlands_tcp.ovpn
+++ b/windows/cstorm_windows-netherlands_tcp.ovpn
@@ -9,19 +9,18 @@ remote windows-netherlands.cryptostorm.nu 443 tcp
 remote windows-netherlands.cryptostorm.org 443 tcp
 remote windows-netherlands.cstorm.pw 443 tcp
 nobind
-comp-lzo
+compress
 down-pre
 reneg-sec 0
 hand-window 17
 verb 4
 mute 3
 auth-user-pass
-ns-cert-type server
+remote-cert-tls server
 auth SHA512
 cipher AES-256-CBC
 tls-cipher TLS-DHE-RSA-WITH-AES-256-CBC-SHA
 tls-client
-key-method 2
 ca ca.crt
 # specification & location of server-verification PKI materials
 # for details, see https://cryptostorm.org/pki

--- a/windows/cstorm_windows-netherlands_tcp.ovpn
+++ b/windows/cstorm_windows-netherlands_tcp.ovpn
@@ -9,7 +9,7 @@ remote windows-netherlands.cryptostorm.nu 443 tcp
 remote windows-netherlands.cryptostorm.org 443 tcp
 remote windows-netherlands.cstorm.pw 443 tcp
 nobind
-compress
+compress lzo
 down-pre
 reneg-sec 0
 hand-window 17

--- a/windows/cstorm_windows-netherlands_udp.ovpn
+++ b/windows/cstorm_windows-netherlands_udp.ovpn
@@ -11,7 +11,7 @@ remote windows-netherlands.cstorm.pw 443 udp
 explicit-exit-notify 3
 fragment 1400
 nobind
-compress
+compress lzo
 down-pre
 reneg-sec 0
 hand-window 17

--- a/windows/cstorm_windows-netherlands_udp.ovpn
+++ b/windows/cstorm_windows-netherlands_udp.ovpn
@@ -11,19 +11,18 @@ remote windows-netherlands.cstorm.pw 443 udp
 explicit-exit-notify 3
 fragment 1400
 nobind
-comp-lzo
+compress
 down-pre
 reneg-sec 0
 hand-window 17
 verb 4
 mute 3
 auth-user-pass
-ns-cert-type server
+remote-cert-tls server
 auth SHA512
 cipher AES-256-CBC
 tls-cipher TLS-DHE-RSA-WITH-AES-256-CBC-SHA
 tls-client
-key-method 2
 ca ca.crt
 # specification & location of server-verification PKI materials
 # for details, see https://cryptostorm.org/pki

--- a/windows/cstorm_windows-paris_tcp.ovpn
+++ b/windows/cstorm_windows-paris_tcp.ovpn
@@ -9,7 +9,7 @@ remote windows-paris.cryptostorm.nu 443 tcp
 remote windows-paris.cryptostorm.org 443 tcp
 remote windows-paris.cstorm.pw 443 tcp
 nobind
-compress
+compress lzo
 down-pre
 reneg-sec 0
 hand-window 17

--- a/windows/cstorm_windows-paris_tcp.ovpn
+++ b/windows/cstorm_windows-paris_tcp.ovpn
@@ -9,19 +9,18 @@ remote windows-paris.cryptostorm.nu 443 tcp
 remote windows-paris.cryptostorm.org 443 tcp
 remote windows-paris.cstorm.pw 443 tcp
 nobind
-comp-lzo
+compress
 down-pre
 reneg-sec 0
 hand-window 17
 verb 4
 mute 3
 auth-user-pass
-ns-cert-type server
+remote-cert-tls server
 auth SHA512
 cipher AES-256-CBC
 tls-cipher TLS-DHE-RSA-WITH-AES-256-CBC-SHA
 tls-client
-key-method 2
 ca ca.crt
 # specification & location of server-verification PKI materials
 # for details, see https://cryptostorm.org/pki

--- a/windows/cstorm_windows-paris_udp.ovpn
+++ b/windows/cstorm_windows-paris_udp.ovpn
@@ -11,7 +11,7 @@ remote windows-paris.cstorm.pw 443 udp
 explicit-exit-notify 3
 fragment 1400
 nobind
-compress
+compress lzo
 down-pre
 reneg-sec 0
 hand-window 17

--- a/windows/cstorm_windows-paris_udp.ovpn
+++ b/windows/cstorm_windows-paris_udp.ovpn
@@ -11,19 +11,18 @@ remote windows-paris.cstorm.pw 443 udp
 explicit-exit-notify 3
 fragment 1400
 nobind
-comp-lzo
+compress
 down-pre
 reneg-sec 0
 hand-window 17
 verb 4
 mute 3
 auth-user-pass
-ns-cert-type server
+remote-cert-tls server
 auth SHA512
 cipher AES-256-CBC
 tls-cipher TLS-DHE-RSA-WITH-AES-256-CBC-SHA
 tls-client
-key-method 2
 ca ca.crt
 # specification & location of server-verification PKI materials
 # for details, see https://cryptostorm.org/pki

--- a/windows/cstorm_windows-poland_tcp.ovpn
+++ b/windows/cstorm_windows-poland_tcp.ovpn
@@ -9,7 +9,7 @@ remote windows-poland.cryptostorm.nu 443 tcp
 remote windows-poland.cryptostorm.org 443 tcp
 remote windows-poland.cstorm.pw 443 tcp
 nobind
-compress
+compress lzo
 down-pre
 reneg-sec 0
 hand-window 17

--- a/windows/cstorm_windows-poland_tcp.ovpn
+++ b/windows/cstorm_windows-poland_tcp.ovpn
@@ -9,19 +9,18 @@ remote windows-poland.cryptostorm.nu 443 tcp
 remote windows-poland.cryptostorm.org 443 tcp
 remote windows-poland.cstorm.pw 443 tcp
 nobind
-comp-lzo
+compress
 down-pre
 reneg-sec 0
 hand-window 17
 verb 4
 mute 3
 auth-user-pass
-ns-cert-type server
+remote-cert-tls server
 auth SHA512
 cipher AES-256-CBC
 tls-cipher TLS-DHE-RSA-WITH-AES-256-CBC-SHA
 tls-client
-key-method 2
 ca ca.crt
 # specification & location of server-verification PKI materials
 # for details, see https://cryptostorm.org/pki

--- a/windows/cstorm_windows-poland_udp.ovpn
+++ b/windows/cstorm_windows-poland_udp.ovpn
@@ -11,19 +11,18 @@ remote windows-poland.cstorm.pw 443 udp
 explicit-exit-notify 3
 fragment 1400
 nobind
-comp-lzo
+compress
 down-pre
 reneg-sec 0
 hand-window 17
 verb 4
 mute 3
 auth-user-pass
-ns-cert-type server
+remote-cert-tls server
 auth SHA512
 cipher AES-256-CBC
 tls-cipher TLS-DHE-RSA-WITH-AES-256-CBC-SHA
 tls-client
-key-method 2
 ca ca.crt
 # specification & location of server-verification PKI materials
 # for details, see https://cryptostorm.org/pki

--- a/windows/cstorm_windows-poland_udp.ovpn
+++ b/windows/cstorm_windows-poland_udp.ovpn
@@ -11,7 +11,7 @@ remote windows-poland.cstorm.pw 443 udp
 explicit-exit-notify 3
 fragment 1400
 nobind
-compress
+compress lzo
 down-pre
 reneg-sec 0
 hand-window 17

--- a/windows/cstorm_windows-rome_tcp.ovpn
+++ b/windows/cstorm_windows-rome_tcp.ovpn
@@ -9,7 +9,7 @@ remote windows-rome.cryptostorm.nu 443 tcp
 remote windows-rome.cryptostorm.org 443 tcp
 remote windows-rome.cstorm.pw 443 tcp
 nobind
-compress
+compress lzo
 down-pre
 reneg-sec 0
 hand-window 17

--- a/windows/cstorm_windows-rome_tcp.ovpn
+++ b/windows/cstorm_windows-rome_tcp.ovpn
@@ -9,19 +9,18 @@ remote windows-rome.cryptostorm.nu 443 tcp
 remote windows-rome.cryptostorm.org 443 tcp
 remote windows-rome.cstorm.pw 443 tcp
 nobind
-comp-lzo
+compress
 down-pre
 reneg-sec 0
 hand-window 17
 verb 4
 mute 3
 auth-user-pass
-ns-cert-type server
+remote-cert-tls server
 auth SHA512
 cipher AES-256-CBC
 tls-cipher TLS-DHE-RSA-WITH-AES-256-CBC-SHA
 tls-client
-key-method 2
 ca ca.crt
 # specification & location of server-verification PKI materials
 # for details, see https://cryptostorm.org/pki

--- a/windows/cstorm_windows-rome_udp.ovpn
+++ b/windows/cstorm_windows-rome_udp.ovpn
@@ -11,7 +11,7 @@ remote windows-rome.cstorm.pw 443 udp
 explicit-exit-notify 3
 fragment 1400
 nobind
-compress
+compress lzo
 down-pre
 reneg-sec 0
 hand-window 17

--- a/windows/cstorm_windows-rome_udp.ovpn
+++ b/windows/cstorm_windows-rome_udp.ovpn
@@ -11,19 +11,18 @@ remote windows-rome.cstorm.pw 443 udp
 explicit-exit-notify 3
 fragment 1400
 nobind
-comp-lzo
+compress
 down-pre
 reneg-sec 0
 hand-window 17
 verb 4
 mute 3
 auth-user-pass
-ns-cert-type server
+remote-cert-tls server
 auth SHA512
 cipher AES-256-CBC
 tls-cipher TLS-DHE-RSA-WITH-AES-256-CBC-SHA
 tls-client
-key-method 2
 ca ca.crt
 # specification & location of server-verification PKI materials
 # for details, see https://cryptostorm.org/pki

--- a/windows/cstorm_windows-spain_tcp.ovpn
+++ b/windows/cstorm_windows-spain_tcp.ovpn
@@ -9,19 +9,18 @@ remote windows-spain.cryptostorm.nu 443 tcp
 remote windows-spain.cryptostorm.org 443 tcp
 remote windows-spain.cstorm.pw 443 tcp
 nobind
-comp-lzo
+compress
 down-pre
 reneg-sec 0
 hand-window 17
 verb 4
 mute 3
 auth-user-pass
-ns-cert-type server
+remote-cert-tls server
 auth SHA512
 cipher AES-256-CBC
 tls-cipher TLS-DHE-RSA-WITH-AES-256-CBC-SHA
 tls-client
-key-method 2
 ca ca.crt
 # specification & location of server-verification PKI materials
 # for details, see https://cryptostorm.org/pki

--- a/windows/cstorm_windows-spain_tcp.ovpn
+++ b/windows/cstorm_windows-spain_tcp.ovpn
@@ -9,7 +9,7 @@ remote windows-spain.cryptostorm.nu 443 tcp
 remote windows-spain.cryptostorm.org 443 tcp
 remote windows-spain.cstorm.pw 443 tcp
 nobind
-compress
+compress lzo
 down-pre
 reneg-sec 0
 hand-window 17

--- a/windows/cstorm_windows-spain_udp.ovpn
+++ b/windows/cstorm_windows-spain_udp.ovpn
@@ -11,7 +11,7 @@ remote windows-spain.cstorm.pw 443 udp
 explicit-exit-notify 3
 fragment 1400
 nobind
-compress
+compress lzo
 down-pre
 reneg-sec 0
 hand-window 17

--- a/windows/cstorm_windows-spain_udp.ovpn
+++ b/windows/cstorm_windows-spain_udp.ovpn
@@ -11,19 +11,18 @@ remote windows-spain.cstorm.pw 443 udp
 explicit-exit-notify 3
 fragment 1400
 nobind
-comp-lzo
+compress
 down-pre
 reneg-sec 0
 hand-window 17
 verb 4
 mute 3
 auth-user-pass
-ns-cert-type server
+remote-cert-tls server
 auth SHA512
 cipher AES-256-CBC
 tls-cipher TLS-DHE-RSA-WITH-AES-256-CBC-SHA
 tls-client
-key-method 2
 ca ca.crt
 # specification & location of server-verification PKI materials
 # for details, see https://cryptostorm.org/pki

--- a/windows/cstorm_windows-switzerland_tcp.ovpn
+++ b/windows/cstorm_windows-switzerland_tcp.ovpn
@@ -9,19 +9,18 @@ remote windows-switzerland.cryptostorm.nu 443 tcp
 remote windows-switzerland.cryptostorm.org 443 tcp
 remote windows-switzerland.cstorm.pw 443 tcp
 nobind
-comp-lzo
+compress
 down-pre
 reneg-sec 0
 hand-window 17
 verb 4
 mute 3
 auth-user-pass
-ns-cert-type server
+remote-cert-tls server
 auth SHA512
 cipher AES-256-CBC
 tls-cipher TLS-DHE-RSA-WITH-AES-256-CBC-SHA
 tls-client
-key-method 2
 ca ca.crt
 # specification & location of server-verification PKI materials
 # for details, see https://cryptostorm.org/pki

--- a/windows/cstorm_windows-switzerland_tcp.ovpn
+++ b/windows/cstorm_windows-switzerland_tcp.ovpn
@@ -9,7 +9,7 @@ remote windows-switzerland.cryptostorm.nu 443 tcp
 remote windows-switzerland.cryptostorm.org 443 tcp
 remote windows-switzerland.cstorm.pw 443 tcp
 nobind
-compress
+compress lzo
 down-pre
 reneg-sec 0
 hand-window 17

--- a/windows/cstorm_windows-switzerland_udp.ovpn
+++ b/windows/cstorm_windows-switzerland_udp.ovpn
@@ -11,19 +11,18 @@ remote windows-switzerland.cstorm.pw 443 udp
 explicit-exit-notify 3
 fragment 1400
 nobind
-comp-lzo
+compress
 down-pre
 reneg-sec 0
 hand-window 17
 verb 4
 mute 3
 auth-user-pass
-ns-cert-type server
+remote-cert-tls server
 auth SHA512
 cipher AES-256-CBC
 tls-cipher TLS-DHE-RSA-WITH-AES-256-CBC-SHA
 tls-client
-key-method 2
 ca ca.crt
 # specification & location of server-verification PKI materials
 # for details, see https://cryptostorm.org/pki

--- a/windows/cstorm_windows-switzerland_udp.ovpn
+++ b/windows/cstorm_windows-switzerland_udp.ovpn
@@ -11,7 +11,7 @@ remote windows-switzerland.cstorm.pw 443 udp
 explicit-exit-notify 3
 fragment 1400
 nobind
-compress
+compress lzo
 down-pre
 reneg-sec 0
 hand-window 17

--- a/windows/cstorm_windows-useast_tcp.ovpn
+++ b/windows/cstorm_windows-useast_tcp.ovpn
@@ -9,19 +9,18 @@ remote windows-useast.cryptostorm.nu 443 tcp
 remote windows-useast.cryptostorm.org 443 tcp
 remote windows-useast.cstorm.pw 443 tcp
 nobind
-comp-lzo
+compress
 down-pre
 reneg-sec 0
 hand-window 17
 verb 4
 mute 3
 auth-user-pass
-ns-cert-type server
+remote-cert-tls server
 auth SHA512
 cipher AES-256-CBC
 tls-cipher TLS-DHE-RSA-WITH-AES-256-CBC-SHA
 tls-client
-key-method 2
 ca ca.crt
 # specification & location of server-verification PKI materials
 # for details, see https://cryptostorm.org/pki

--- a/windows/cstorm_windows-useast_tcp.ovpn
+++ b/windows/cstorm_windows-useast_tcp.ovpn
@@ -9,7 +9,7 @@ remote windows-useast.cryptostorm.nu 443 tcp
 remote windows-useast.cryptostorm.org 443 tcp
 remote windows-useast.cstorm.pw 443 tcp
 nobind
-compress
+compress lzo
 down-pre
 reneg-sec 0
 hand-window 17

--- a/windows/cstorm_windows-useast_udp.ovpn
+++ b/windows/cstorm_windows-useast_udp.ovpn
@@ -11,7 +11,7 @@ remote windows-useast.cstorm.pw 443 udp
 explicit-exit-notify 3
 fragment 1400
 nobind
-compress
+compress lzo
 down-pre
 reneg-sec 0
 hand-window 17

--- a/windows/cstorm_windows-useast_udp.ovpn
+++ b/windows/cstorm_windows-useast_udp.ovpn
@@ -11,19 +11,18 @@ remote windows-useast.cstorm.pw 443 udp
 explicit-exit-notify 3
 fragment 1400
 nobind
-comp-lzo
+compress
 down-pre
 reneg-sec 0
 hand-window 17
 verb 4
 mute 3
 auth-user-pass
-ns-cert-type server
+remote-cert-tls server
 auth SHA512
 cipher AES-256-CBC
 tls-cipher TLS-DHE-RSA-WITH-AES-256-CBC-SHA
 tls-client
-key-method 2
 ca ca.crt
 # specification & location of server-verification PKI materials
 # for details, see https://cryptostorm.org/pki

--- a/windows/cstorm_windows-usnorth_tcp.ovpn
+++ b/windows/cstorm_windows-usnorth_tcp.ovpn
@@ -9,7 +9,7 @@ remote windows-usnorth.cryptostorm.nu 443 tcp
 remote windows-usnorth.cryptostorm.org 443 tcp
 remote windows-usnorth.cstorm.pw 443 tcp
 nobind
-compress
+compress lzo
 down-pre
 reneg-sec 0
 hand-window 17

--- a/windows/cstorm_windows-usnorth_tcp.ovpn
+++ b/windows/cstorm_windows-usnorth_tcp.ovpn
@@ -9,19 +9,18 @@ remote windows-usnorth.cryptostorm.nu 443 tcp
 remote windows-usnorth.cryptostorm.org 443 tcp
 remote windows-usnorth.cstorm.pw 443 tcp
 nobind
-comp-lzo
+compress
 down-pre
 reneg-sec 0
 hand-window 17
 verb 4
 mute 3
 auth-user-pass
-ns-cert-type server
+remote-cert-tls server
 auth SHA512
 cipher AES-256-CBC
 tls-cipher TLS-DHE-RSA-WITH-AES-256-CBC-SHA
 tls-client
-key-method 2
 ca ca.crt
 # specification & location of server-verification PKI materials
 # for details, see https://cryptostorm.org/pki

--- a/windows/cstorm_windows-usnorth_udp.ovpn
+++ b/windows/cstorm_windows-usnorth_udp.ovpn
@@ -11,7 +11,7 @@ remote windows-usnorth.cstorm.pw 443 udp
 explicit-exit-notify 3
 fragment 1400
 nobind
-compress
+compress lzo
 down-pre
 reneg-sec 0
 hand-window 17

--- a/windows/cstorm_windows-usnorth_udp.ovpn
+++ b/windows/cstorm_windows-usnorth_udp.ovpn
@@ -11,19 +11,18 @@ remote windows-usnorth.cstorm.pw 443 udp
 explicit-exit-notify 3
 fragment 1400
 nobind
-comp-lzo
+compress
 down-pre
 reneg-sec 0
 hand-window 17
 verb 4
 mute 3
 auth-user-pass
-ns-cert-type server
+remote-cert-tls server
 auth SHA512
 cipher AES-256-CBC
 tls-cipher TLS-DHE-RSA-WITH-AES-256-CBC-SHA
 tls-client
-key-method 2
 ca ca.crt
 # specification & location of server-verification PKI materials
 # for details, see https://cryptostorm.org/pki

--- a/windows/cstorm_windows-ussouth_tcp.ovpn
+++ b/windows/cstorm_windows-ussouth_tcp.ovpn
@@ -9,7 +9,7 @@ remote windows-ussouth.cryptostorm.nu 443 tcp
 remote windows-ussouth.cryptostorm.org 443 tcp
 remote windows-ussouth.cstorm.pw 443 tcp
 nobind
-compress
+compress lzo
 down-pre
 reneg-sec 0
 hand-window 17

--- a/windows/cstorm_windows-ussouth_tcp.ovpn
+++ b/windows/cstorm_windows-ussouth_tcp.ovpn
@@ -9,19 +9,18 @@ remote windows-ussouth.cryptostorm.nu 443 tcp
 remote windows-ussouth.cryptostorm.org 443 tcp
 remote windows-ussouth.cstorm.pw 443 tcp
 nobind
-comp-lzo
+compress
 down-pre
 reneg-sec 0
 hand-window 17
 verb 4
 mute 3
 auth-user-pass
-ns-cert-type server
+remote-cert-tls server
 auth SHA512
 cipher AES-256-CBC
 tls-cipher TLS-DHE-RSA-WITH-AES-256-CBC-SHA
 tls-client
-key-method 2
 ca ca.crt
 # specification & location of server-verification PKI materials
 # for details, see https://cryptostorm.org/pki

--- a/windows/cstorm_windows-ussouth_udp.ovpn
+++ b/windows/cstorm_windows-ussouth_udp.ovpn
@@ -11,19 +11,18 @@ remote windows-ussouth.cstorm.pw 443 udp
 explicit-exit-notify 3
 fragment 1400
 nobind
-comp-lzo
+compress
 down-pre
 reneg-sec 0
 hand-window 17
 verb 4
 mute 3
 auth-user-pass
-ns-cert-type server
+remote-cert-tls server
 auth SHA512
 cipher AES-256-CBC
 tls-cipher TLS-DHE-RSA-WITH-AES-256-CBC-SHA
 tls-client
-key-method 2
 ca ca.crt
 # specification & location of server-verification PKI materials
 # for details, see https://cryptostorm.org/pki

--- a/windows/cstorm_windows-ussouth_udp.ovpn
+++ b/windows/cstorm_windows-ussouth_udp.ovpn
@@ -11,7 +11,7 @@ remote windows-ussouth.cstorm.pw 443 udp
 explicit-exit-notify 3
 fragment 1400
 nobind
-compress
+compress lzo
 down-pre
 reneg-sec 0
 hand-window 17

--- a/windows/cstorm_windows-uswest_tcp.ovpn
+++ b/windows/cstorm_windows-uswest_tcp.ovpn
@@ -9,19 +9,18 @@ remote windows-uswest.cryptostorm.nu 443 tcp
 remote windows-uswest.cryptostorm.org 443 tcp
 remote windows-uswest.cstorm.pw 443 tcp
 nobind
-comp-lzo
+compress
 down-pre
 reneg-sec 0
 hand-window 17
 verb 4
 mute 3
 auth-user-pass
-ns-cert-type server
+remote-cert-tls server
 auth SHA512
 cipher AES-256-CBC
 tls-cipher TLS-DHE-RSA-WITH-AES-256-CBC-SHA
 tls-client
-key-method 2
 ca ca.crt
 # specification & location of server-verification PKI materials
 # for details, see https://cryptostorm.org/pki

--- a/windows/cstorm_windows-uswest_tcp.ovpn
+++ b/windows/cstorm_windows-uswest_tcp.ovpn
@@ -9,7 +9,7 @@ remote windows-uswest.cryptostorm.nu 443 tcp
 remote windows-uswest.cryptostorm.org 443 tcp
 remote windows-uswest.cstorm.pw 443 tcp
 nobind
-compress
+compress lzo
 down-pre
 reneg-sec 0
 hand-window 17

--- a/windows/cstorm_windows-uswest_udp.ovpn
+++ b/windows/cstorm_windows-uswest_udp.ovpn
@@ -11,19 +11,18 @@ remote windows-uswest.cstorm.pw 443 udp
 explicit-exit-notify 3
 fragment 1400
 nobind
-comp-lzo
+compress
 down-pre
 reneg-sec 0
 hand-window 17
 verb 4
 mute 3
 auth-user-pass
-ns-cert-type server
+remote-cert-tls server
 auth SHA512
 cipher AES-256-CBC
 tls-cipher TLS-DHE-RSA-WITH-AES-256-CBC-SHA
 tls-client
-key-method 2
 ca ca.crt
 # specification & location of server-verification PKI materials
 # for details, see https://cryptostorm.org/pki

--- a/windows/cstorm_windows-uswest_udp.ovpn
+++ b/windows/cstorm_windows-uswest_udp.ovpn
@@ -11,7 +11,7 @@ remote windows-uswest.cstorm.pw 443 udp
 explicit-exit-notify 3
 fragment 1400
 nobind
-compress
+compress lzo
 down-pre
 reneg-sec 0
 hand-window 17


### PR DESCRIPTION
**Replace or remove options deprecated in OpenVPN v2.4 and/or removed in OpenVPN v2.5**

[key-method](https://community.openvpn.net/openvpn/wiki/DeprecatedOptions#a--key-method) (removed)
[comp-lzo](https://community.openvpn.net/openvpn/wiki/DeprecatedOptions#a--comp-lzo) (replaced by compress)
[ns-cert-type](https://community.openvpn.net/openvpn/wiki/DeprecatedOptions#a--ns-cert-type) (replaced by remote-cert-tls) 

Full list: https://community.openvpn.net/openvpn/wiki/DeprecatedOptions